### PR TITLE
NGEE Arctic IM1 - Polygonal tundra

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -49,6 +49,9 @@ _TESTS = {
             "ERS.f19_g16.I20TRGSWCNPECACNTBC.elm-eca_f19_g16_I20TRGSWCNPECACNTBC",
             "ERS.f19_g16.I20TRGSWCNPRDCTCBC.elm-ctc_f19_g16_I20TRGSWCNPRDCTCBC",
             "ERS.r05_r05.ICNPRDCTCBC.elm-cbudget",
+            "ERS.ELM_USRDAT.I1850CNPRDCTCBC.elm-usrpft_default_I1850CNPRDCTCBC",
+            "ERS.ELM_USRDAT.I1850CNPRDCTCBC.elm-usrpft_codetest_I1850CNPRDCTCBC",
+            "ERS.ELM_USRDAT.I1850CNPRDCTCBC.elm-polygonal_tundra"
             )
         },
 
@@ -94,11 +97,8 @@ _TESTS = {
             "SMS.r05_r05.IELM.elm-topounit",
             "ERS.ELM_USRDAT.I1850ELM.elm-usrdat",
             "ERS.r05_r05.IELM.elm-lnd_rof_2way",
-            "ERS.ELM_USRDAT.I1850CNPRDCTCBC.elm-usrpft_default_I1850CNPRDCTCBC",
-            "ERS.ELM_USRDAT.I1850CNPRDCTCBC.elm-usrpft_codetest_I1850CNPRDCTCBC",
             "ERS.r05_r05.IELM.elm-V2_ELM_MOSART_features",
-            "ERS.ELM_USRDAT.IELM.elm-surface_water_dynamics",
-            "ERS.ELM_USRDAT.I1850CNPRDCTCBC.elm-polygonal_tundra"
+            "ERS.ELM_USRDAT.IELM.elm-surface_water_dynamics"
             )
         },
 

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -98,6 +98,7 @@ _TESTS = {
             "ERS.ELM_USRDAT.I1850CNPRDCTCBC.elm-usrpft_codetest_I1850CNPRDCTCBC",
             "ERS.r05_r05.IELM.elm-V2_ELM_MOSART_features",
             "ERS.ELM_USRDAT.IELM.elm-surface_water_dynamics"
+            "ERS.ELM_USRDAT.I1850CNPRDCTCBC.elm-polygonal_tundra"
             )
         },
 

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -97,7 +97,7 @@ _TESTS = {
             "ERS.ELM_USRDAT.I1850CNPRDCTCBC.elm-usrpft_default_I1850CNPRDCTCBC",
             "ERS.ELM_USRDAT.I1850CNPRDCTCBC.elm-usrpft_codetest_I1850CNPRDCTCBC",
             "ERS.r05_r05.IELM.elm-V2_ELM_MOSART_features",
-            "ERS.ELM_USRDAT.IELM.elm-surface_water_dynamics"
+            "ERS.ELM_USRDAT.IELM.elm-surface_water_dynamics",
             "ERS.ELM_USRDAT.I1850CNPRDCTCBC.elm-polygonal_tundra"
             )
         },

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -2228,4 +2228,7 @@ this mask will have smb calculated over the entire global land surface
 <use_fan use_fates=".true." >.false.</use_fan>
 <use_fan fan_mode='disable'>.false.</use_fan>
 
+<!-- NGEE Arctic Options -->
+<use_polygonal_tundra>.false.</use_polygonal_tundra>;
+
 </namelist_defaults>

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -2230,5 +2230,6 @@ this mask will have smb calculated over the entire global land surface
 
 <!-- NGEE Arctic Options -->
 <use_polygonal_tundra>.false.</use_polygonal_tundra>;
+<use_arctic_init>.false.</use_arctic_init>;
 
 </namelist_defaults>

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -2161,6 +2161,16 @@ default: 0
 </entry>
 
 <!-- ========================================================================================  -->
+<!-- NGEE Arctic Options                                                                       -->
+<!-- ========================================================================================  -->
+
+<entry id="use_arctic_init" type="logical" category="default_settings"
+	group="elm_inparm" value=".false.">
+Cold-start initialization conditions in tundra start saturated and frozen.
+<default>Default: .false.</default>
+</entry>
+
+<!-- ========================================================================================  -->
 <!-- Namelist options for soil erosion model                                                   -->
 <!-- ========================================================================================  -->
 

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -2222,4 +2222,14 @@ not be called.
 <default>Default: 0</default>
 </entry>
 
+<!-- ========================================================================================  -->
+<!-- NGEE Arctic Options                                                                       -->
+<!-- ========================================================================================  -->
+
+<entry id="use_polygonal_tundra" type="logical" category="default_settings"
+	group="elm_inparm" value=".false.">
+Use polygonal tundra parameterizations for ice wedge polygon microtopography and inindation fraction
+<default>Default: .false.</default>
+</entry>
+
 </namelist_definition>

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/polygonal_tundra/shell_commands
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/polygonal_tundra/shell_commands
@@ -1,0 +1,10 @@
+./xmlchange LND_DOMAIN_FILE=domain.lnd.1x1pt_icycape_c240909.nc
+./xmlchange ATM_DOMAIN_FILE=domain.lnd.1x1pt_icycape_c240909.nc
+./xmlchange LND_DOMAIN_PATH="\$DIN_LOC_ROOT/share/domains/domain.clm"
+./xmlchange ATM_DOMAIN_PATH="\$DIN_LOC_ROOT/share/domains/domain.clm"
+./xmlchange DATM_MODE=CLM1PT
+./xmlchange DATM_CLMNCEP_YR_START=2000
+./xmlchange DATM_CLMNCEP_YR_END=2000
+./xmlchange ELM_USRDAT_NAME=ELMERA5
+./xmlchange NTASKS=1
+./xmlchange NTHRDS=1

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/polygonal_tundra/shell_commands
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/polygonal_tundra/shell_commands
@@ -2,9 +2,8 @@
 ./xmlchange ATM_DOMAIN_FILE=domain.lnd.1x1pt_icycape_c240909.nc
 ./xmlchange LND_DOMAIN_PATH="\$DIN_LOC_ROOT/share/domains/domain.clm"
 ./xmlchange ATM_DOMAIN_PATH="\$DIN_LOC_ROOT/share/domains/domain.clm"
-./xmlchange DATM_MODE=CLM1PT
+./xmlchange DATM_MODE=CLMGSWP3v1
 ./xmlchange DATM_CLMNCEP_YR_START=2000
 ./xmlchange DATM_CLMNCEP_YR_END=2000
-./xmlchange ELM_USRDAT_NAME=ELMERA5
 ./xmlchange NTASKS=1
 ./xmlchange NTHRDS=1

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/polygonal_tundra/user_nl_elm
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/polygonal_tundra/user_nl_elm
@@ -1,1 +1,2 @@
+use_polygonal_tundra = .true.
 fsurdat = '$DIN_LOC_ROOT/lnd/clm2/surfdata_map/surfdata_1x1pt_IcyCape_polygons_c240909.nc'

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/polygonal_tundra/user_nl_elm
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/polygonal_tundra/user_nl_elm
@@ -1,2 +1,3 @@
 use_polygonal_tundra = .true.
+use_arctic_init = .true.
 fsurdat = '$DIN_LOC_ROOT/lnd/clm2/surfdata_map/surfdata_1x1pt_IcyCape_polygons_c240909.nc'

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/polygonal_tundra/user_nl_elm
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/polygonal_tundra/user_nl_elm
@@ -1,0 +1,1 @@
+fsurdat = '$DIN_LOC_ROOT/lnd/clm2/surfdata_map/surfdata_1x1pt_IcyCape_polygons_c240909.nc'

--- a/components/elm/src/biogeophys/ActiveLayerMod.F90
+++ b/components/elm/src/biogeophys/ActiveLayerMod.F90
@@ -188,18 +188,21 @@ contains
          ! subsidence is integral of melt profile:
          subsidence(c) = subsidence(c) + sum(melt_profile)
 
+         ! limit subsidence to 0.4 m
+         subsidence(c) = min(0.4_r8, subsidence(c))
+
          ! update ice wedge polygon microtopographic parameters if in polygonal ground
-         ! TODO: need to retrieve landunit this column is on.
-         if (lun_pp%ispolygon(c)) then
-            if (lun_pp%polygontype(c) .eq. ilowcenpoly) then
+         !rf - min/max logic may be redunant w/ subsidence limiter above
+         if (lun_pp%ispolygon(col_pp%landunit(c))) then
+            if (lun_pp%polygontype(col_pp%landunit(c)) .eq. ilowcenpoly) then
                rmax(c) = 0.4_r8
                vexc(c) = 0.2_r8
-               ddep(c) = 0.15_r8 ! TODO - update based on subsidence calcs.
-            elseif (lun_pp%polygontype(c) .eq. iflatcenpoly) then
-               rmax(c) = 0.1_r8  ! TODO - update based on subsidence calcs.
-               vexc(c) = 0.05_r8 ! TODO - update based on subsidence calcs.
-               ddep(c) = 0.01_r8 ! TODO - update based on subsidence calcs.
-            elseif (lun_pp%polygontype(c) .eq. ihighcenpoly) then
+               ddep(c) = min(0.05_r8, max(0.15_r8 - 0.25_r8*subsidence(c), 0.15_r8))
+            elseif (lun_pp%polygontype(col_pp%landunit(c)) .eq. iflatcenpoly) then
+               rmax(c) = min(0.1_r8, max(0.4_r8, 0.1_r8 + 0.75_r8*subsidence(c)))
+               vexc(c) = min(0.05_r8, max(0.2_r8, 0.05_r8 + 0.375_r8*subsidence(c)))
+               ddep(c) = min(0.01_r8, max(0.05_r8, 0.01_r8 + 0.1_r8*subsidence(c)))
+            elseif (lun_pp%polygontype(col_pp%landunit(c)) .eq. ihighcenpoly) then
                rmax(c) = 0.4_r8
                vexc(c) = 0.2_r8
                ddep(c) = 0.05_r8

--- a/components/elm/src/biogeophys/ActiveLayerMod.F90
+++ b/components/elm/src/biogeophys/ActiveLayerMod.F90
@@ -184,7 +184,7 @@ contains
          ! update subsidence based on change in ALT
          ! melt_profile stores the amount of excess_ice
          ! melted in this timestep.
-         do j = nlevgrnd-1,1,-1
+         do j = 1,nlevgrnd
             if (j < k_frz) then
                melt_profile(j) = 0.0_r8
             else if (j .eq. k_frz) then

--- a/components/elm/src/biogeophys/ActiveLayerMod.F90
+++ b/components/elm/src/biogeophys/ActiveLayerMod.F90
@@ -193,7 +193,6 @@ contains
            melt_profile(:) = 0._r8
 
            do j = nlevgrnd,1,-1 ! note, this will go from bottom to top
-              !write(iulog,*) "processing level j,",j,k_frz,excess_ice(c,j)
               if (j .gt. k_frz + 1) then ! all layers below k_frz + 1 remain frozen
                 melt_profile(j) = 0.0_r8
               else if (j .eq. k_frz + 1) then ! first layer below the 'thawed' layer

--- a/components/elm/src/biogeophys/ActiveLayerMod.F90
+++ b/components/elm/src/biogeophys/ActiveLayerMod.F90
@@ -189,15 +189,22 @@ contains
                melt_profile(j) = 0.0_r8
             else if (j .eq. k_frz) then
                melt_profile(j) = excess_ice(c,j) + ((z2-alt(c))/(z2-z1))*excess_ice(c,j+1) ! TODO: check indices here!!
+               ! remove melted excess ice:
+               excess_ice(c,j) = 0._r8
+               excess_ice(c,j+1) = excess_ice(c,j+1)*(1._r8 - min(1._r8,(z2-alt(c))/(z2-z1)))
             else
                melt_profile(j) = excess_ice(c,j)
+               ! remove melted excess ice
+               excess_ice(c,j) = 0._r8
             end if
             ! calculate subsidence at this layer:
             melt_profile(j) = melt_profile(j) * dzsoi(j)
          end do
 
          ! subsidence is integral of melt profile:
-         subsidence(c) = subsidence(c) + sum(melt_profile)
+         if ((year .ge. 1989) .and. (altmax_ever(c) .ge. altmax_1989(c))) then
+            subsidence(c) = subsidence(c) + sum(melt_profile)
+         end if
 
          ! limit subsidence to 0.4 m
          subsidence(c) = min(0.4_r8, subsidence(c))

--- a/components/elm/src/biogeophys/ActiveLayerMod.F90
+++ b/components/elm/src/biogeophys/ActiveLayerMod.F90
@@ -88,10 +88,10 @@ contains
          altmax_1989_indx     =>    canopystate_vars%altmax_1989_indx_col,      & ! Output:  [integer  (:)   ]  index of maximum ALT in 1989
          altmax_ever_indx     =>    canopystate_vars%altmax_ever_indx_col,      & ! Output:  [integer  (:)   ]  maximum thaw depth since initialization
          excess_ice           =>    col_ws%excess_ice                    ,      & ! Input:   [real(r8) (:,:) ]  depth variable excess ice content in soil column (-)
-         rmax                 =>    col_pp%iwp_microrel                  ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon microtopographic relief (m)
-         vexc                 =>    col_pp%iwp_exclvol                   ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon excluded volume (m)
-         ddep                 =>    col_pp%iwp_ddep                      ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon depression depth (m)
-         subsidence           =>    col_pp%iwp_subsidence                       & ! Input/output:[real(r8) (:)   ]  ice wedge polygon subsidence (m)
+         rmax                 =>    col_ws%iwp_microrel                  ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon microtopographic relief (m)
+         vexc                 =>    col_ws%iwp_exclvol                   ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon excluded volume (m)
+         ddep                 =>    col_ws%iwp_ddep                      ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon depression depth (m)
+         subsidence           =>    col_ws%iwp_subsidence                       & ! Input/output:[real(r8) (:)   ]  ice wedge polygon subsidence (m)
          )
 
       ! on a set annual timestep, update annual maxima

--- a/components/elm/src/biogeophys/ActiveLayerMod.F90
+++ b/components/elm/src/biogeophys/ActiveLayerMod.F90
@@ -71,16 +71,21 @@ contains
     real(r8), dimension(nlevgrnd) :: melt_profile ! profile of melted excess ice
     !-----------------------------------------------------------------------
 
+    ! RF NOTE: use of 1989 ALT in these parameterizations is somewhat of a placeholder used to compare against
+    ! ATS runs for NGEE Arctic Phase 3. It should ultimately be replaced by a more physically based threshold
+    ! later on.
     associate(                                                                &
          t_soisno             =>    col_es%t_soisno        ,    & ! Input:   [real(r8) (:,:) ]  soil temperature (Kelvin)  (-nlevsno+1:nlevgrnd)
 
          alt                  =>    canopystate_vars%alt_col             ,      & ! Output:  [real(r8) (:)   ]  current depth of thaw
          altmax               =>    canopystate_vars%altmax_col          ,      & ! Output:  [real(r8) (:)   ]  maximum annual depth of thaw
          altmax_lastyear      =>    canopystate_vars%altmax_lastyear_col ,      & ! Output:  [real(r8) (:)   ]  prior year maximum annual depth of thaw
+         altmax_1989          =>    canopystate_vars%altmax_1989_col     ,      & ! Output:  [real(r8) (:)   ]  maximum ALT in 1989
          altmax_ever          =>    canopystate_vars%altmax_ever_col     ,      & ! Output:  [real(r8) (:)   ]  maximum thaw depth since initialization
          alt_indx             =>    canopystate_vars%alt_indx_col        ,      & ! Output:  [integer  (:)   ]  current depth of thaw
          altmax_indx          =>    canopystate_vars%altmax_indx_col     ,      & ! Output:  [integer  (:)   ]  maximum annual depth of thaw
          altmax_lastyear_indx =>    canopystate_vars%altmax_lastyear_indx_col , & ! Output:  [integer  (:)   ]  prior year maximum annual depth of thaw
+         altmax_1989_indx     =>    canopystate_vars%altmax_1989_indx_col,      & ! Output:  [integer  (:)   ]  index of maximum ALT in 1989
          altmax_ever_indx     =>    canopystate_vars%altmax_ever_indx_col,      & ! Output:  [integer  (:)   ]  maximum thaw depth since initialization
          excess_ice           =>    col_ws%excess_ice                    ,      & ! Input:   [real(r8) (:,:) ]  depth variable excess ice content in soil column (-)
          rmax                 =>    col_pp%iwp_microrel                  ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon microtopographic relief (m)
@@ -154,7 +159,6 @@ contains
             endif
          endif
 
-
          ! if appropriate, update maximum annual active layer thickness
          if (alt(c) > altmax(c)) then
             altmax(c) = alt(c)
@@ -168,6 +172,13 @@ contains
                 altmax_ever(c) = 0._r8
                 altmax_ever_indx(c) = 0
             endif
+         endif
+
+         ! special loop for if year = 1989, see above note regarding
+         ! replacing with more physically based mechanism.
+         if (year .eq. 1989) then
+            altmax_1989(c) = altmax(c)
+            altmax_1989_indx(c) = altmax_indx(c)
          endif
 
          ! update subsidence based on change in ALT

--- a/components/elm/src/biogeophys/ActiveLayerMod.F90
+++ b/components/elm/src/biogeophys/ActiveLayerMod.F90
@@ -215,11 +215,11 @@ contains
             if (lun_pp%polygontype(col_pp%landunit(c)) .eq. ilowcenpoly) then
                rmax(c) = 0.4_r8
                vexc(c) = 0.2_r8
-               ddep(c) = min(0.05_r8, max(0.15_r8 - 0.25_r8*subsidence(c), 0.15_r8))
+               ddep(c) = max(0.05_r8, 0.15_r8 - 0.25_r8*subsidence(c))
             elseif (lun_pp%polygontype(col_pp%landunit(c)) .eq. iflatcenpoly) then
-               rmax(c) = min(0.1_r8, max(0.4_r8, 0.1_r8 + 0.75_r8*subsidence(c)))
-               vexc(c) = min(0.05_r8, max(0.2_r8, 0.05_r8 + 0.375_r8*subsidence(c)))
-               ddep(c) = min(0.01_r8, max(0.05_r8, 0.01_r8 + 0.1_r8*subsidence(c)))
+               rmax(c) = min(0.4_r8, 0.1_r8 + 0.75_r8*subsidence(c))
+               vexc(c) = min(0.2_r8, 0.05_r8 + 0.375_r8*subsidence(c))
+               ddep(c) = min(0.05_r8, 0.01_r8 + 0.1_r8*subsidence(c))
             elseif (lun_pp%polygontype(col_pp%landunit(c)) .eq. ihighcenpoly) then
                rmax(c) = 0.4_r8
                vexc(c) = 0.2_r8

--- a/components/elm/src/biogeophys/CanopyHydrologyMod.F90
+++ b/components/elm/src/biogeophys/CanopyHydrologyMod.F90
@@ -795,9 +795,9 @@ contains
      !
      ! !LOCAL VARIABLES:
      integer :: c,f,l,k          ! indices
-     real(r8):: d,fd,dfdd      ! temporary variable for frac_h2oscs iteration
-     real(r8):: sigma          ! microtopography pdf sigma in mm
-     real(r8):: swc            ! surface water content in m
+     real(r8):: d,fd,dfdd        ! temporary variable for frac_h2oscs iteration
+     real(r8):: sigma            ! microtopography pdf sigma in mm
+     real(r8):: swc              ! surface water content in m
      real(r8):: min_h2osfc
      !-----------------------------------------------------------------------
 
@@ -805,8 +805,8 @@ contains
           micro_sigma  => col_pp%micro_sigma  , & ! Input:  [real(r8) (:)   ] microtopography pdf sigma (m)
 
           iwp_microrel => col_pp%iwp_microrel , & ! Input:  [real(r8) (:)   ] ice wedge polygon microtopographic relief (m)
-          iwp_exclvol  => col_pp%iwp_exclvol  , & ! Input:  [real(r8) (:)   ] microtopography pdf sigma (m)
-          iwp_ddep     => col_pp%iwp_ddep     , & ! Input:  [real(r8) (:)   ] microtopography pdf sigma (m)
+          iwp_exclvol  => col_pp%iwp_exclvol  , & ! Input:  [real(r8) (:)   ] ice wedge polygon excluded volume (m)
+          iwp_ddep     => col_pp%iwp_ddep     , & ! Input:  [real(r8) (:)   ] ice wedge polygon depression depth (m)
 
           h2osno       => col_ws%h2osno       , & ! Input:  [real(r8) (:)   ] snow water (mm H2O)
 

--- a/components/elm/src/biogeophys/CanopyHydrologyMod.F90
+++ b/components/elm/src/biogeophys/CanopyHydrologyMod.F90
@@ -804,9 +804,9 @@ contains
      associate(                                 &
           micro_sigma  => col_pp%micro_sigma  , & ! Input:  [real(r8) (:)   ] microtopography pdf sigma (m)
 
-          iwp_microrel => col_pp%iwp_microrel , & ! Input:  [real(r8) (:)   ] ice wedge polygon microtopographic relief (m)
-          iwp_exclvol  => col_pp%iwp_exclvol  , & ! Input:  [real(r8) (:)   ] ice wedge polygon excluded volume (m)
-          iwp_ddep     => col_pp%iwp_ddep     , & ! Input:  [real(r8) (:)   ] ice wedge polygon depression depth (m)
+          iwp_microrel => col_ws%iwp_microrel , & ! Input:  [real(r8) (:)   ] ice wedge polygon microtopographic relief (m)
+          iwp_exclvol  => col_ws%iwp_exclvol  , & ! Input:  [real(r8) (:)   ] ice wedge polygon excluded volume (m)
+          iwp_ddep     => col_ws%iwp_ddep     , & ! Input:  [real(r8) (:)   ] ice wedge polygon depression depth (m)
 
           h2osno       => col_ws%h2osno       , & ! Input:  [real(r8) (:)   ] snow water (mm H2O)
 

--- a/components/elm/src/biogeophys/CanopyHydrologyMod.F90
+++ b/components/elm/src/biogeophys/CanopyHydrologyMod.F90
@@ -800,17 +800,18 @@ contains
      real(r8):: min_h2osfc
      !-----------------------------------------------------------------------
 
-     associate(                                 & 
-          micro_sigma  => col_pp%micro_sigma  , & ! Input:  [real(r8) (:)   ] microtopography pdf sigma (m)                     
+     associate(                                 &
+          micro_sigma  => col_pp%micro_sigma  , & ! Input:  [real(r8) (:)   ] microtopography pdf sigma (m)
 
-          h2osno       => col_ws%h2osno       , & ! Input:  [real(r8) (:)   ] snow water (mm H2O)                               
-          
-          h2osoi_liq   => col_ws%h2osoi_liq   , & ! Output: [real(r8) (:,:) ] liquid water (col,lyr) [kg/m2]                  
-          h2osfc       => col_ws%h2osfc       , & ! Output: [real(r8) (:)   ] surface water (mm)                                
-          frac_sno     => col_ws%frac_sno     , & ! Output: [real(r8) (:)   ] fraction of ground covered by snow (0 to 1)       
-          frac_sno_eff => col_ws%frac_sno_eff , & ! Output: [real(r8) (:)   ] eff. fraction of ground covered by snow (0 to 1)  
-          frac_h2osfc  => col_ws%frac_h2osfc  , & ! Output: [real(r8) (:)   ] col fractional area with surface water greater than zero 
-          frac_h2osfc_act => col_ws%frac_h2osfc_act & ! Output: [real(r8) (:)   ] col fractional area with surface water greater than zero
+          h2osno       => col_ws%h2osno            , & ! Input:  [real(r8) (:)   ] snow water (mm H2O)
+          excess_ice   => col_ws%excess_ice        , & ! Input:  [real(r8) (:,:)   ] excess ground ice [kg/m2]
+
+          h2osoi_liq   => col_ws%h2osoi_liq        , & ! Output: [real(r8) (:,:) ] liquid water (col,lyr) [kg/m2]
+          h2osfc       => col_ws%h2osfc            , & ! Output: [real(r8) (:)   ] surface water (mm)
+          frac_sno     => col_ws%frac_sno          , & ! Output: [real(r8) (:)   ] fraction of ground covered by snow (0 to 1)
+          frac_sno_eff => col_ws%frac_sno_eff      , & ! Output: [real(r8) (:)   ] eff. fraction of ground covered by snow (0 to 1)
+          frac_h2osfc  => col_ws%frac_h2osfc       , & ! Output: [real(r8) (:)   ] col fractional area with surface water greater than zero
+          frac_h2osfc_act => col_ws%frac_h2osfc_act  & ! Output: [real(r8) (:)   ] col fractional area with surface water greater than zero
           )
 
        ! arbitrary lower limit on h2osfc for safer numerics...

--- a/components/elm/src/biogeophys/CanopyHydrologyMod.F90
+++ b/components/elm/src/biogeophys/CanopyHydrologyMod.F90
@@ -783,7 +783,7 @@ contains
      ! !USES:
      use shr_const_mod   , only : shr_const_pi
      use shr_spfn_mod    , only : erf => shr_spfn_erf
-     use landunit_varcon , only : istsoil, istcrop, ispolygon
+     use landunit_varcon , only : istsoil, istcrop
      !
      ! !ARGUMENTS:
      type(bounds_type)     , intent(in)           :: bounds           
@@ -839,25 +839,25 @@ contains
 
                 if (lun_pp%ispolygon(l)) then
                     ! calculate water depth and inundation fraction if column is polygonal
-                    swc = h2osfc(c)/1000 ! convert to m
+                    swc = h2osfc(c)/1000_r8 ! convert to m
 
-                    if (swc > iwp_microrel - iwp_exclvol) then
-                        d = swc + iwp_exclvol
+                    if (swc > iwp_microrel(c) - iwp_exclvol(c)) then
+                        d = swc + iwp_exclvol(c)
                     else
                         d = 0.0
                         do k=1,10
-                            fd = (2_r8*iwp_exclvol - iwp_microrel) * (d/iwp_microrel)**3_r8 &
-                                 + (2_r8*iwp_microrel - 3_r8*iwp_exclvol) * (d/iwp_microrel)**2_r8 &
+                            fd = (2_r8*iwp_exclvol(c) - iwp_microrel(c)) * (d/iwp_microrel(c))**3_r8 &
+                                 + (2_r8*iwp_microrel(c) - 3_r8*iwp_exclvol(c)) * (d/iwp_microrel(c))**2_r8 &
                                  - swc
-                            dfdd = (3_r8/iwp_microrel) * (2_r8*iwp_exclvol - iwp_microrel) * (d/iwp_microrel)**2_r8 &
-                                   + (2_r8/iwp_microrel) * (2_r8*iwp_microrel - 3_r8*iwp_exclvol) * (d/iwp_microrel)
+                            dfdd = (3_r8/iwp_microrel(c)) * (2_r8*iwp_exclvol(c) - iwp_microrel(c)) * (d/iwp_microrel(c))**2_r8 &
+                                   + (2_r8/iwp_microrel(c)) * (2_r8*iwp_microrel(c) - 3_r8*iwp_exclvol(c)) * (d/iwp_microrel(c))
                             d = d - fd/dfdd
                         enddo
                     endif
 
                     !--  update the submerged areal fraction using the new d value
-                    frac_h2osfc(c) = (3_r8/iwp_microrel) * (2_r8*iwp_exclvol - iwp_microrel) * (d/iwp_microrel)**2_r8 &
-                                     + (2_r8/iwp_microrel) * (2_r8*iwp_microrel - 3_r8*iwp_exclvol) * (d/iwp_microrel)
+                    frac_h2osfc(c) = (3_r8/iwp_microrel(c)) * (2_r8*iwp_exclvol(c) - iwp_microrel(c)) * (d/iwp_microrel(c))**2_r8 &
+                                     + (2_r8/iwp_microrel(c)) * (2_r8*iwp_microrel(c) - 3_r8*iwp_exclvol(c)) * (d/iwp_microrel(c))
 
                 else ! calculate water depth and inudation fraction if column is non-polygonal
                     d=0.0

--- a/components/elm/src/biogeophys/CanopyHydrologyMod.F90
+++ b/components/elm/src/biogeophys/CanopyHydrologyMod.F90
@@ -844,13 +844,16 @@ contains
                     if (swc > iwp_microrel(c) - iwp_exclvol(c)) then
                         d = swc + iwp_exclvol(c)
                     else
-                        d = 0.0
+                        d = swc + iwp_exclvol(c)
                         do k=1,10
                             fd = (2_r8*iwp_exclvol(c) - iwp_microrel(c)) * (d/iwp_microrel(c))**3_r8 &
                                  + (2_r8*iwp_microrel(c) - 3_r8*iwp_exclvol(c)) * (d/iwp_microrel(c))**2_r8 &
                                  - swc
                             dfdd = (3_r8/iwp_microrel(c)) * (2_r8*iwp_exclvol(c) - iwp_microrel(c)) * (d/iwp_microrel(c))**2_r8 &
                                    + (2_r8/iwp_microrel(c)) * (2_r8*iwp_microrel(c) - 3_r8*iwp_exclvol(c)) * (d/iwp_microrel(c))
+                            if (dfdd < 1.0e-12_r8) then
+                              write(iulog,*) "careful! getting close to dividing by 0..."
+                            end if
                             d = d - fd/dfdd
                         enddo
                     endif

--- a/components/elm/src/biogeophys/CanopyStateType.F90
+++ b/components/elm/src/biogeophys/CanopyStateType.F90
@@ -62,8 +62,10 @@ module CanopyStateType
      integer  , pointer :: alt_indx_col             (:)   ! col current depth of thaw
      real(r8) , pointer :: altmax_col               (:)   ! col maximum annual depth of thaw
      real(r8) , pointer :: altmax_lastyear_col      (:)   ! col prior year maximum annual depth of thaw
+     real(r8) , pointer :: altmax_ever_col          (:)   ! col maximum thaw depth from beginning of simulation
      integer  , pointer :: altmax_indx_col          (:)   ! col maximum annual depth of thaw
      integer  , pointer :: altmax_lastyear_indx_col (:)   ! col prior year maximum annual depth of thaw
+     integer  , pointer :: altmax_ever_indx_col     (:)   ! col maximum thaw depth from beginning of simulation
 
      real(r8) , pointer :: dewmx_patch              (:)   ! patch maximum allowed dew [mm]
 
@@ -142,9 +144,11 @@ contains
     allocate(this%alt_col                  (begc:endc))           ; this%alt_col                  (:)   = spval;
     allocate(this%altmax_col               (begc:endc))           ; this%altmax_col               (:)   = spval
     allocate(this%altmax_lastyear_col      (begc:endc))           ; this%altmax_lastyear_col      (:)   = spval
+    allocate(this%altmax_ever_col          (begc:endc))           ; this%altmax_ever_col          (:)   = spval
     allocate(this%alt_indx_col             (begc:endc))           ; this%alt_indx_col             (:)   = huge(1)
     allocate(this%altmax_indx_col          (begc:endc))           ; this%altmax_indx_col          (:)   = huge(1)
     allocate(this%altmax_lastyear_indx_col (begc:endc))           ; this%altmax_lastyear_indx_col (:)   = huge(1)
+    allocate(this%altmax_ever_indx_col     (begc:endc))           ; this%altmax_ever_indx_col     (:)   = huge(1) 
 
     allocate(this%dewmx_patch              (begp:endp))           ; this%dewmx_patch              (:)   = spval
     allocate(this%dleaf_patch              (begp:endp))           ; this%dleaf_patch              (:)   = spval
@@ -277,6 +281,11 @@ contains
        call hist_addfld1d (fname='ALTMAX_LASTYEAR', units='m', &
             avgflag='A', long_name='maximum prior year active layer thickness', &
             ptr_col=this%altmax_lastyear_col)
+
+       this%altmax_ever_col(begc:endc) = spval
+       call hist_addfld1d (fname='ALTMAX_EVER', units='m', &
+            avgflag='A', long_name='maximum ever active layer thickness throughout simulation', &
+            ptr_col=this%altmax_ever_col)
     end if
 
     ! Allow active layer fields to be optionally output even if not running CN
@@ -296,6 +305,11 @@ contains
        call hist_addfld1d (fname='ALTMAX_LASTYEAR', units='m', &
             avgflag='A', long_name='maximum prior year active layer thickness', &
             ptr_col=this%altmax_lastyear_col, default='inactive')
+
+       this%altmax_ever_col(begc:endc) = spval
+       call hist_addfld1d (fname='ALTMAX_EVER', units='m', &
+            avgflag='A', long_name='maximum ever active layer thickness throughout simulation', &
+            ptr_col=this%altmax_ever_col, default='inactive')
     end if
 
     ! Accumulated fields
@@ -502,9 +516,11 @@ contains
           this%alt_col(c)                  = 0._r8
           this%altmax_col(c)               = 0._r8
           this%altmax_lastyear_col(c)      = 0._r8
+          this%altmax_ever_col(c)          = 0._r8
           this%alt_indx_col(c)             = 0
           this%altmax_indx_col(c)          = 0
           this%altmax_lastyear_indx_col(c) = 0
+          this%altmax_ever_indx_col(c)     = 0
        end if
     end do
 
@@ -572,12 +588,18 @@ contains
        call restartvar(ncid=ncid, flag=flag, varname='altmax_lastyear', xtype=ncd_double,  &
             dim1name='column', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%altmax_lastyear_col)
+       call restartvar(ncid=ncid, flag=flag, varname='altmax_ever', xtype=ncd_double,  &
+            dim1name='column', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%altmax_ever_col)
        call restartvar(ncid=ncid, flag=flag, varname='altmax_indx', xtype=ncd_int,  &
             dim1name='column', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%altmax_indx_col)
        call restartvar(ncid=ncid, flag=flag, varname='altmax_lastyear_indx', xtype=ncd_int,  &
             dim1name='column', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%altmax_lastyear_indx_col)
+       call restartvar(ncid=ncid, flag=flag, varname='altmax_ever_indx', xtype=ncd_int,  &
+            dim1name='column', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%altmax_ever_indx_col)
     end if
     if ( use_hydrstress ) then
        call restartvar(ncid=ncid, flag=flag, varname='vegwp', xtype=ncd_double, &

--- a/components/elm/src/biogeophys/CanopyStateType.F90
+++ b/components/elm/src/biogeophys/CanopyStateType.F90
@@ -62,9 +62,11 @@ module CanopyStateType
      integer  , pointer :: alt_indx_col             (:)   ! col current depth of thaw
      real(r8) , pointer :: altmax_col               (:)   ! col maximum annual depth of thaw
      real(r8) , pointer :: altmax_lastyear_col      (:)   ! col prior year maximum annual depth of thaw
+     real(r8) , pointer :: altmax_1989_col          (:)   ! col maximum annual thaw depth in 1989 RF note: temporary for IM1!
      real(r8) , pointer :: altmax_ever_col          (:)   ! col maximum thaw depth from beginning of simulation
      integer  , pointer :: altmax_indx_col          (:)   ! col maximum annual depth of thaw
      integer  , pointer :: altmax_lastyear_indx_col (:)   ! col prior year maximum annual depth of thaw
+     integer  , pointer :: altmax_1989_indx_col     (:)   ! col 1989 maximum thaw depth RF note: temporary for IM1!
      integer  , pointer :: altmax_ever_indx_col     (:)   ! col maximum thaw depth from beginning of simulation
 
      real(r8) , pointer :: dewmx_patch              (:)   ! patch maximum allowed dew [mm]
@@ -144,11 +146,13 @@ contains
     allocate(this%alt_col                  (begc:endc))           ; this%alt_col                  (:)   = spval;
     allocate(this%altmax_col               (begc:endc))           ; this%altmax_col               (:)   = spval
     allocate(this%altmax_lastyear_col      (begc:endc))           ; this%altmax_lastyear_col      (:)   = spval
+    allocate(this%altmax_1989_col          (begc:endc))           ; this%altmax_1989_col          (:)   = spval
     allocate(this%altmax_ever_col          (begc:endc))           ; this%altmax_ever_col          (:)   = spval
     allocate(this%alt_indx_col             (begc:endc))           ; this%alt_indx_col             (:)   = huge(1)
     allocate(this%altmax_indx_col          (begc:endc))           ; this%altmax_indx_col          (:)   = huge(1)
     allocate(this%altmax_lastyear_indx_col (begc:endc))           ; this%altmax_lastyear_indx_col (:)   = huge(1)
-    allocate(this%altmax_ever_indx_col     (begc:endc))           ; this%altmax_ever_indx_col     (:)   = huge(1) 
+    allocate(this%altmax_1989_indx_col     (begc:endc))           ; this%altmax_1989_indx_col     (:)   = huge(1)
+    allocate(this%altmax_ever_indx_col     (begc:endc))           ; this%altmax_ever_indx_col     (:)   = huge(1)
 
     allocate(this%dewmx_patch              (begp:endp))           ; this%dewmx_patch              (:)   = spval
     allocate(this%dleaf_patch              (begp:endp))           ; this%dleaf_patch              (:)   = spval
@@ -282,6 +286,11 @@ contains
             avgflag='A', long_name='maximum prior year active layer thickness', &
             ptr_col=this%altmax_lastyear_col)
 
+       this%altmax_1989_col(begc:endc) = spval
+       call hist_addfld1d (fname='ALTMAX_1989', units='m', &
+            avgflag='A', long_name='maximum 1989 active layer thickness', &
+            ptr_col=this%altmax_1989_col)
+
        this%altmax_ever_col(begc:endc) = spval
        call hist_addfld1d (fname='ALTMAX_EVER', units='m', &
             avgflag='A', long_name='maximum ever active layer thickness throughout simulation', &
@@ -305,6 +314,11 @@ contains
        call hist_addfld1d (fname='ALTMAX_LASTYEAR', units='m', &
             avgflag='A', long_name='maximum prior year active layer thickness', &
             ptr_col=this%altmax_lastyear_col, default='inactive')
+
+       this%altmax_1989_col(begc:endc) = spval
+       call hist_addfld1d (fname='ALTMAX_1989', units='m', &
+            avgflag='A', long_name='maximum 1989 active layer thickness', &
+            ptr_col=this%altmax_1989_col, default='inactive')
 
        this%altmax_ever_col(begc:endc) = spval
        call hist_addfld1d (fname='ALTMAX_EVER', units='m', &
@@ -516,10 +530,12 @@ contains
           this%alt_col(c)                  = 0._r8
           this%altmax_col(c)               = 0._r8
           this%altmax_lastyear_col(c)      = 0._r8
+          this%altmax_1989_col(c)          = 0._r8
           this%altmax_ever_col(c)          = 0._r8
           this%alt_indx_col(c)             = 0
           this%altmax_indx_col(c)          = 0
           this%altmax_lastyear_indx_col(c) = 0
+          this%altmax_1989_indx_col(c)     = 0
           this%altmax_ever_indx_col(c)     = 0
        end if
     end do
@@ -588,6 +604,9 @@ contains
        call restartvar(ncid=ncid, flag=flag, varname='altmax_lastyear', xtype=ncd_double,  &
             dim1name='column', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%altmax_lastyear_col)
+       call restartvar(ncid=ncid, flag=flag, varname='altmax_1989', xtype=ncd_double,  &
+            dim1name='column', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%altmax_1989_col)
        call restartvar(ncid=ncid, flag=flag, varname='altmax_ever', xtype=ncd_double,  &
             dim1name='column', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%altmax_ever_col)
@@ -597,6 +616,9 @@ contains
        call restartvar(ncid=ncid, flag=flag, varname='altmax_lastyear_indx', xtype=ncd_int,  &
             dim1name='column', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%altmax_lastyear_indx_col)
+       call restartvar(ncid=ncid, flag=flag, varname='altmax_1989_indx', xtype=ncd_double,  &
+            dim1name='column', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%altmax_1989_indx_col)
        call restartvar(ncid=ncid, flag=flag, varname='altmax_ever_indx', xtype=ncd_int,  &
             dim1name='column', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%altmax_ever_indx_col)

--- a/components/elm/src/biogeophys/CanopyStateType.F90
+++ b/components/elm/src/biogeophys/CanopyStateType.F90
@@ -10,6 +10,7 @@ module CanopyStateType
   use elm_varcon      , only : spval,ispval
   use elm_varpar      , only : nlevcan, nvegwcs
   use elm_varctl      , only : iulog, use_cn, use_fates, use_hydrstress, use_fates_sp
+  use elm_varctl      , only : use_polygonal_tundra
   use LandunitType    , only : lun_pp
   use ColumnType      , only : col_pp
   use VegetationType       , only : veg_pp
@@ -62,10 +63,10 @@ module CanopyStateType
      integer  , pointer :: alt_indx_col             (:)   ! col current depth of thaw
      real(r8) , pointer :: altmax_col               (:)   ! col maximum annual depth of thaw
      real(r8) , pointer :: altmax_lastyear_col      (:)   ! col prior year maximum annual depth of thaw
-     real(r8) , pointer :: altmax_1989_col          (:)   ! col maximum annual thaw depth in 1989 RF note: temporary for IM1!
-     real(r8) , pointer :: altmax_ever_col          (:)   ! col maximum thaw depth from beginning of simulation
      integer  , pointer :: altmax_indx_col          (:)   ! col maximum annual depth of thaw
      integer  , pointer :: altmax_lastyear_indx_col (:)   ! col prior year maximum annual depth of thaw
+     real(r8) , pointer :: altmax_1989_col          (:)   ! col maximum annual thaw depth in 1989 RF note: temporary for IM1!
+     real(r8) , pointer :: altmax_ever_col          (:)   ! col maximum thaw depth from beginning of simulation
      integer  , pointer :: altmax_1989_indx_col     (:)   ! col 1989 maximum thaw depth RF note: temporary for IM1!
      integer  , pointer :: altmax_ever_indx_col     (:)   ! col maximum thaw depth from beginning of simulation
 
@@ -286,15 +287,17 @@ contains
             avgflag='A', long_name='maximum prior year active layer thickness', &
             ptr_col=this%altmax_lastyear_col)
 
-       this%altmax_1989_col(begc:endc) = spval
-       call hist_addfld1d (fname='ALTMAX_1989', units='m', &
-            avgflag='A', long_name='maximum 1989 active layer thickness', &
-            ptr_col=this%altmax_1989_col)
+       if (use_polygonal_tundra) then
+          this%altmax_1989_col(begc:endc) = spval
+          call hist_addfld1d (fname='ALTMAX_1989', units='m', &
+               avgflag='A', long_name='maximum 1989 active layer thickness', &
+               ptr_col=this%altmax_1989_col)
 
-       this%altmax_ever_col(begc:endc) = spval
-       call hist_addfld1d (fname='ALTMAX_EVER', units='m', &
-            avgflag='A', long_name='maximum ever active layer thickness throughout simulation', &
-            ptr_col=this%altmax_ever_col)
+          this%altmax_ever_col(begc:endc) = spval
+          call hist_addfld1d (fname='ALTMAX_EVER', units='m', &
+               avgflag='A', long_name='maximum ever active layer thickness throughout simulation', &
+               ptr_col=this%altmax_ever_col)
+       end if
     end if
 
     ! Allow active layer fields to be optionally output even if not running CN
@@ -315,15 +318,17 @@ contains
             avgflag='A', long_name='maximum prior year active layer thickness', &
             ptr_col=this%altmax_lastyear_col, default='inactive')
 
-       this%altmax_1989_col(begc:endc) = spval
-       call hist_addfld1d (fname='ALTMAX_1989', units='m', &
-            avgflag='A', long_name='maximum 1989 active layer thickness', &
-            ptr_col=this%altmax_1989_col, default='inactive')
+       if (use_polygonal_tundra) then
+          this%altmax_1989_col(begc:endc) = spval
+          call hist_addfld1d (fname='ALTMAX_1989', units='m', &
+               avgflag='A', long_name='maximum 1989 active layer thickness', &
+               ptr_col=this%altmax_1989_col, default='inactive')
 
-       this%altmax_ever_col(begc:endc) = spval
-       call hist_addfld1d (fname='ALTMAX_EVER', units='m', &
-            avgflag='A', long_name='maximum ever active layer thickness throughout simulation', &
-            ptr_col=this%altmax_ever_col, default='inactive')
+          this%altmax_ever_col(begc:endc) = spval
+          call hist_addfld1d (fname='ALTMAX_EVER', units='m', &
+               avgflag='A', long_name='maximum ever active layer thickness throughout simulation', &
+               ptr_col=this%altmax_ever_col, default='inactive')
+       end if
     end if
 
     ! Accumulated fields
@@ -604,25 +609,27 @@ contains
        call restartvar(ncid=ncid, flag=flag, varname='altmax_lastyear', xtype=ncd_double,  &
             dim1name='column', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%altmax_lastyear_col)
-       call restartvar(ncid=ncid, flag=flag, varname='altmax_1989', xtype=ncd_double,  &
-            dim1name='column', long_name='', units='', &
-            interpinic_flag='interp', readvar=readvar, data=this%altmax_1989_col)
-       call restartvar(ncid=ncid, flag=flag, varname='altmax_ever', xtype=ncd_double,  &
-            dim1name='column', long_name='', units='', &
-            interpinic_flag='interp', readvar=readvar, data=this%altmax_ever_col)
        call restartvar(ncid=ncid, flag=flag, varname='altmax_indx', xtype=ncd_int,  &
             dim1name='column', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%altmax_indx_col)
        call restartvar(ncid=ncid, flag=flag, varname='altmax_lastyear_indx', xtype=ncd_int,  &
             dim1name='column', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%altmax_lastyear_indx_col)
-       call restartvar(ncid=ncid, flag=flag, varname='altmax_1989_indx', xtype=ncd_double,  &
-            dim1name='column', long_name='', units='', &
-            interpinic_flag='interp', readvar=readvar, data=this%altmax_1989_indx_col)
-       call restartvar(ncid=ncid, flag=flag, varname='altmax_ever_indx', xtype=ncd_int,  &
-            dim1name='column', long_name='', units='', &
-            interpinic_flag='interp', readvar=readvar, data=this%altmax_ever_indx_col)
-    end if
+       if (use_polygonal_tundra) then
+          call restartvar(ncid=ncid, flag=flag, varname='altmax_1989_indx', xtype=ncd_double,  &
+               dim1name='column', long_name='', units='', &
+               interpinic_flag='interp', readvar=readvar, data=this%altmax_1989_indx_col)
+          call restartvar(ncid=ncid, flag=flag, varname='altmax_ever_indx', xtype=ncd_int,  &
+               dim1name='column', long_name='', units='', &
+               interpinic_flag='interp', readvar=readvar, data=this%altmax_ever_indx_col)
+          call restartvar(ncid=ncid, flag=flag, varname='altmax_1989', xtype=ncd_double,  &
+               dim1name='column', long_name='', units='', &
+               interpinic_flag='interp', readvar=readvar, data=this%altmax_1989_col)
+          call restartvar(ncid=ncid, flag=flag, varname='altmax_ever', xtype=ncd_double,  &
+               dim1name='column', long_name='', units='', &
+               interpinic_flag='interp', readvar=readvar, data=this%altmax_ever_col)
+       end if ! polygonal tundra
+    end if ! cn or fates
     if ( use_hydrstress ) then
        call restartvar(ncid=ncid, flag=flag, varname='vegwp', xtype=ncd_double, &
             dim1name='pft', dim2name='vegwcs', switchdim=.true., &

--- a/components/elm/src/biogeophys/SoilHydrologyMod.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyMod.F90
@@ -201,13 +201,18 @@ contains
 
       do fc = 1, num_hydrologyc
          c = filter_hydrologyc(fc)
-
-         ! assume qinmax large relative to qflx_top_soil in control
-         if (origflag == 1) then
-            qflx_surf(c) =  fcov(c) * qflx_top_soil(c)
+         l = col_pp%landunit(c)
+         ! no qflx_surf in polygonal ground
+         if (lun_pp%ispolygon(l)) then
+            qflx_surf(c) = 0
          else
-            ! only send fast runoff directly to streams
-            qflx_surf(c) =   fsat(c) * qflx_top_soil(c)
+            ! assume qinmax large relative to qflx_top_soil in control
+            if (origflag == 1) then
+               qflx_surf(c) =  fcov(c) * qflx_top_soil(c)
+            else
+               ! only send fast runoff directly to streams
+               qflx_surf(c) =   fsat(c) * qflx_top_soil(c)
+            endif
          endif
       end do
 
@@ -267,7 +272,7 @@ contains
      use elm_varcon       , only : denh2o, denice, roverg, wimp, mu, tfrz
      use elm_varcon       , only : pondmx, watmin
      use column_varcon    , only : icol_roof, icol_road_imperv, icol_sunwall, icol_shadewall, icol_road_perv
-     use landunit_varcon  , only : istsoil, istcrop
+     use landunit_varcon  , only : istsoil, istcrop, ilowcenpoly
      use elm_time_manager , only : get_step_size, get_nstep
      use atm2lndType      , only : atm2lnd_type ! land river two way coupling
      use lnd2atmType      , only : lnd2atm_type
@@ -313,6 +318,9 @@ contains
      real(r8) :: d
      real(r8) :: h2osoi_vol
      real(r8) :: basis                                      ! temporary, variable soil moisture holding capacity
+     real(r8) :: vdep                                       ! temporary, ice wedge polygon volumetric depression depth (m)
+     real(r8) :: phi_eff                                    ! temporary, polygonal ground effective subsidence (maxes out at 0.4) (m)
+     real(r8) :: swc                                        ! temporary, polygonal surface water content in m
      ! in top VIC layers for runoff calculation
      real(r8) :: rsurf_vic                                  ! temp VIC surface runoff
      real(r8) :: top_moist(bounds%begc:bounds%endc)         ! temporary, soil moisture in top VIC layers
@@ -328,7 +336,11 @@ contains
           dz                   =>    col_pp%dz                   , & ! Input:  [real(r8) (:,:) ]  layer depth (m)
           nlev2bed             =>    col_pp%nlevbed              , & ! Input:  [integer  (:)   ]  number of layers to bedrock
           cgridcell            =>    col_pp%gridcell             , & ! Input:  [integer  (:)   ]  column's gridcell    
-          wtgcell              =>    col_pp%wtgcell              , & ! Input:  [real(r8) (:)   ]  weight (relative to gridcell) 
+          wtgcell              =>    col_pp%wtgcell              , & ! Input:  [real(r8) (:)   ]  weight (relative to gridcell)
+          iwp_microrel         =>    col_pp%iwp_microrel         , & ! Input:  [real(r8) (:)   ]  ice wedge polygon microtopographic relief (m)
+          iwp_exclvol          =>    col_pp%iwp_exclvol          , & ! Input:  [real(r8) (:)   ]  ice wedge polygon excluded volume (m)
+          iwp_ddep             =>    col_pp%iwp_ddep             , & ! Input:  [real(r8) (:)   ]  ice wedge polygon depression depth (m)
+          meangradz            =>    col_pp%meangradz            , & ! Input:  [real(r8) (:)   ]  mean topographic gradient at the column level (unitless)
 
           t_soisno             =>    col_es%t_soisno             , & ! Input:  [real(r8) (:,:) ]  soil temperature (Kelvin)
 
@@ -514,15 +526,36 @@ contains
                 endif
              endif
 
-             ! limit runoff to value of storage above S(pc)
-             if(h2osfc(c) >= h2osfc_thresh(c) .and. h2osfcflag/=0) then
-                ! spatially variable k_wet
-                k_wet=1.0_r8 * sin((rpi/180.) * col_pp%topo_slope(c))
-                qflx_h2osfc_surf(c) = k_wet * frac_infclust * (h2osfc(c) - h2osfc_thresh(c))
-
-                qflx_h2osfc_surf(c)=min(qflx_h2osfc_surf(c),(h2osfc(c) - h2osfc_thresh(c))/dtime)
+             if (lun_pp%ispolygon(col_pp%landunit(c))) then
+                vdep = (2_r8*iwp_exclvol(c) - iwp_microrel(c)) * (iwp_ddep(c)/iwp_microrel(c))**3_r8 &
+                       + (2_r8*iwp_microrel(c) - 3_r8*iwp_exclvol(c)) * (iwp_ddep(c)/iwp_microrel(c))**2_r8
+                phi_eff = min(subsidence, 0.4)  !fix this variable when available to pull from alt calculations
+                swc = h2osfc(c)/1000_r8 ! convert to m
+                
+                if (swc >= vdep) then
+                   if (lun_pp%polygontype(col_pp%landunit(c)) == ilowcenpoly) then
+                      k_wet = (2890_r8*phi_eff**4 - 1171.1_r8*phi_eff**3 + 144.94_r8*phi_eff**2 + 1.682_r8*phi_eff + 2.028) &
+                              * (710.3_r8*meangradz(c)**2 - 28.736_r8*meangradz(c) + 12.74_r8)
+                   else
+                      k_wet = 24.925_r8 * (710.3_r8*meangradz(c)**2 - 28.736_r8*meangradz(c) + 12.74_r8)
+                   endif
+                   qflx_h2osfc_surf(c) = k_wet * (swc - vdep)
+                   qflx_h2osfc_surf(c) = min(qflx_h2osfc_surf(c), (swc - vdep)*1000_r8/dtime)
+                else
+                   qflx_h2osfc_surf(c) = 0._r8
+                endif
+                
              else
-                qflx_h2osfc_surf(c)= 0._r8
+                ! limit runoff to value of storage above S(pc)
+                if(h2osfc(c) >= h2osfc_thresh(c) .and. h2osfcflag/=0) then
+                   ! spatially variable k_wet
+                   k_wet=1.0_r8 * sin((rpi/180.) * col_pp%topo_slope(c))
+                   qflx_h2osfc_surf(c) = k_wet * frac_infclust * (h2osfc(c) - h2osfc_thresh(c))
+
+                   qflx_h2osfc_surf(c)=min(qflx_h2osfc_surf(c),(h2osfc(c) - h2osfc_thresh(c))/dtime)
+                else
+                   qflx_h2osfc_surf(c)= 0._r8
+                endif
              endif
 
              ! cutoff lower limit
@@ -696,7 +729,7 @@ contains
      real(r8) :: q_perch
      real(r8) :: q_perch_max
      real(r8) :: dflag=0._r8
-	 real(r8) :: qcharge_temp
+     real(r8) :: qcharge_temp
      !-----------------------------------------------------------------------
 
      associate(                                                            &
@@ -783,7 +816,7 @@ contains
        ! Water table changes due to qcharge
        do fc = 1, num_hydrologyc
           c = filter_hydrologyc(fc)
-       	  nlevbed = nlev2bed(c)
+             nlevbed = nlev2bed(c)
 
           !scs: use analytical expression for aquifer specific yield
           rous = watsat(c,nlevbed) &
@@ -791,7 +824,7 @@ contains
           rous=max(rous,0.02_r8)
 
           !--  water table is below the soil column  --------------------------------------
-		      g = col_pp%gridcell(c)
+              g = col_pp%gridcell(c)
           l = col_pp%landunit(c)
           qcharge_temp = qcharge(c)
 
@@ -799,7 +832,7 @@ contains
           zwt(c) = zwt(c) + (qflx_grnd_irrig_col(c) * dtime)/1000._r8/rous
 
           if(jwt(c) == nlevbed) then
-	           if (.not. (zengdecker_2009_with_var_soil_thick)) then
+               if (.not. (zengdecker_2009_with_var_soil_thick)) then
                 wa(c)  = wa(c) + qcharge(c)  * dtime
                 zwt(c) = zwt(c) - (qcharge(c)  * dtime)/1000._r8/rous
              end if
@@ -865,7 +898,7 @@ contains
        ! perched water table code
        do fc = 1, num_hydrologyc
           c = filter_hydrologyc(fc)
-       	  nlevbed = nlev2bed(c)
+             nlevbed = nlev2bed(c)
 
           ! define frost table as first frozen layer with unfrozen layer above it
           if(t_soisno(c,1) > tfrz) then
@@ -1132,7 +1165,7 @@ contains
 
        do fc = 1, num_hydrologyc
           c = filter_hydrologyc(fc)
-       	  nlevbed = nlev2bed(c)
+             nlevbed = nlev2bed(c)
           jwt(c) = nlevbed
           ! allow jwt to equal zero when zwt is in top layer
           do j = 1,nlevbed
@@ -1142,7 +1175,7 @@ contains
                 else
                    jwt(c) = j-1
                    exit
-	        end if
+            end if
              end if
           enddo
        end do
@@ -1153,7 +1186,7 @@ contains
        ! perched water table code
        do fc = 1, num_hydrologyc
           c = filter_hydrologyc(fc)
-       	  nlevbed = nlev2bed(c)
+             nlevbed = nlev2bed(c)
 
           !  specify maximum drainage rate
           q_perch_max = 1.e-5_r8 * sin(col_pp%topo_slope(c) * (rpi/180._r8))
@@ -1357,11 +1390,11 @@ contains
                 ! make sure baseflow isn't negative
                 rsub_top(c) = max(0._r8, rsub_top(c))
              else
-	        if (jwt(c) == nlevbed .and. zengdecker_2009_with_var_soil_thick) then
+            if (jwt(c) == nlevbed .and. zengdecker_2009_with_var_soil_thick) then
                    rsub_top(c)    = 0._r8
                 else
                    rsub_top(c)    = imped * rsub_top_max* exp(-fff(c)*zwt(c))
-		end if
+        end if
              end if
 
              if (use_vsfm) rsub_top(c) = 0._r8
@@ -1373,10 +1406,10 @@ contains
 
              !--  water table is below the soil column  --------------------------------------
              if(jwt(c) == nlevbed) then
-	        if (zengdecker_2009_with_var_soil_thick) then
-         	   if (-1._r8 * smp_l(c,nlevbed) < 0.5_r8 * dzmm(c,nlevbed)) then
-           	      zwt(c) = z(c,nlevbed) - (smp_l(c,nlevbed) / 1000._r8)
-		   end if
+            if (zengdecker_2009_with_var_soil_thick) then
+                if (-1._r8 * smp_l(c,nlevbed) < 0.5_r8 * dzmm(c,nlevbed)) then
+                     zwt(c) = z(c,nlevbed) - (smp_l(c,nlevbed) / 1000._r8)
+           end if
                    rsub_top(c) = imped * rsub_top_max * exp(-fff(c) * zwt(c))
                    rsub_top_tot = - rsub_top(c) * dtime
                    s_y = watsat(c,nlevbed) &
@@ -1391,8 +1424,8 @@ contains
                    else
                       zwt(c) = zi(c,nlevbed)
                    end if
-	           if (rsub_top_tot < 0.) then
-	              rsub_top(c) = rsub_top(c) + rsub_top_tot / dtime
+               if (rsub_top_tot < 0.) then
+                  rsub_top(c) = rsub_top(c) + rsub_top_tot / dtime
                       rsub_top_tot = 0.
                    end if
                 else
@@ -1488,7 +1521,7 @@ contains
 
        do fc = 1, num_hydrologyc
           c = filter_hydrologyc(fc)
-      	  nlevbed = nlev2bed(c)
+            nlevbed = nlev2bed(c)
           do j = nlevbed,2,-1
              xsi(c)            = max(h2osoi_liq(c,j)-eff_porosity(c,j)*dzmm(c,j),0._r8)
              if (use_vsfm) then
@@ -1536,8 +1569,8 @@ contains
 
        do fc = 1, num_hydrologyc
           c = filter_hydrologyc(fc)
-       	  nlevbed = nlev2bed(c)
-       	  do j = 1, nlevbed-1
+             nlevbed = nlev2bed(c)
+             do j = 1, nlevbed-1
              if (h2osoi_liq(c,j) < watmin) then
                 xs(c) = watmin - h2osoi_liq(c,j)
                 ! deepen water table if water is passed from below zwt layer
@@ -1555,8 +1588,8 @@ contains
        ! Get water for bottom layer from layers above if possible
        do fc = 1, num_hydrologyc
           c = filter_hydrologyc(fc)
-       	  nlevbed = nlev2bed(c)
-       	  j = nlevbed
+             nlevbed = nlev2bed(c)
+             j = nlevbed
           if (h2osoi_liq(c,j) < watmin) then
              xs(c) = watmin-h2osoi_liq(c,j)
              searchforwater: do i = nlevbed-1, 1, -1

--- a/components/elm/src/biogeophys/SoilHydrologyMod.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyMod.F90
@@ -272,7 +272,7 @@ contains
      use elm_varcon       , only : denh2o, denice, roverg, wimp, mu, tfrz
      use elm_varcon       , only : pondmx, watmin
      use column_varcon    , only : icol_roof, icol_road_imperv, icol_sunwall, icol_shadewall, icol_road_perv
-     use landunit_varcon  , only : istsoil, istcrop, ilowcenpoly
+     use landunit_varcon  , only : istsoil, istcrop, ilowcenpoly, iflatcenpoly, ihighcenpoly
      use elm_time_manager , only : get_step_size, get_nstep
      use atm2lndType      , only : atm2lnd_type ! land river two way coupling
      use lnd2atmType      , only : lnd2atm_type

--- a/components/elm/src/biogeophys/SoilHydrologyMod.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyMod.F90
@@ -540,7 +540,7 @@ contains
                    else
                       k_wet = 24.925_r8 * (710.3_r8*meangradz(c)**2 - 28.736_r8*meangradz(c) + 12.74_r8)
                    endif
-                   qflx_h2osfc_surf(c) = k_wet * (swc - vdep)
+                   qflx_h2osfc_surf(c) = k_wet * (swc - vdep) / 86400_r8 ! coefficients estimated for mm/day; convert from mm/day -> mm/s
                    qflx_h2osfc_surf(c) = min(qflx_h2osfc_surf(c), (swc - vdep)*1000_r8/dtime)
                 else
                    qflx_h2osfc_surf(c) = 0._r8

--- a/components/elm/src/biogeophys/SoilHydrologyMod.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyMod.F90
@@ -340,6 +340,7 @@ contains
           iwp_microrel         =>    col_pp%iwp_microrel         , & ! Input:  [real(r8) (:)   ]  ice wedge polygon microtopographic relief (m)
           iwp_exclvol          =>    col_pp%iwp_exclvol          , & ! Input:  [real(r8) (:)   ]  ice wedge polygon excluded volume (m)
           iwp_ddep             =>    col_pp%iwp_ddep             , & ! Input:  [real(r8) (:)   ]  ice wedge polygon depression depth (m)
+          iwp_subsidence       =>    col_pp%iwp_subsidence       , & ! Input:  [real(r8) (:)   ]  ice wedge polygon ground subsidence (m)
           meangradz            =>    col_pp%meangradz            , & ! Input:  [real(r8) (:)   ]  mean topographic gradient at the column level (unitless)
 
           t_soisno             =>    col_es%t_soisno             , & ! Input:  [real(r8) (:,:) ]  soil temperature (Kelvin)
@@ -529,7 +530,7 @@ contains
              if (lun_pp%ispolygon(col_pp%landunit(c))) then
                 vdep = (2_r8*iwp_exclvol(c) - iwp_microrel(c)) * (iwp_ddep(c)/iwp_microrel(c))**3_r8 &
                        + (2_r8*iwp_microrel(c) - 3_r8*iwp_exclvol(c)) * (iwp_ddep(c)/iwp_microrel(c))**2_r8
-                phi_eff = min(subsidence, 0.4)  !fix this variable when available to pull from alt calculations
+                phi_eff = min(iwp_subsidence(c), 0.4)  !fix this variable when available to pull from alt calculations
                 swc = h2osfc(c)/1000_r8 ! convert to m
                 
                 if (swc >= vdep) then

--- a/components/elm/src/biogeophys/SoilHydrologyMod.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyMod.F90
@@ -204,7 +204,7 @@ contains
          l = col_pp%landunit(c)
          ! no qflx_surf in polygonal ground
          if (lun_pp%ispolygon(l)) then
-            qflx_surf(c) = 0
+            qflx_surf(c) = 0._r8
          else
             ! assume qinmax large relative to qflx_top_soil in control
             if (origflag == 1) then
@@ -817,7 +817,7 @@ contains
        ! Water table changes due to qcharge
        do fc = 1, num_hydrologyc
           c = filter_hydrologyc(fc)
-             nlevbed = nlev2bed(c)
+          nlevbed = nlev2bed(c)
 
           !scs: use analytical expression for aquifer specific yield
           rous = watsat(c,nlevbed) &
@@ -825,7 +825,7 @@ contains
           rous=max(rous,0.02_r8)
 
           !--  water table is below the soil column  --------------------------------------
-              g = col_pp%gridcell(c)
+          g = col_pp%gridcell(c)
           l = col_pp%landunit(c)
           qcharge_temp = qcharge(c)
 
@@ -833,10 +833,10 @@ contains
           zwt(c) = zwt(c) + (qflx_grnd_irrig_col(c) * dtime)/1000._r8/rous
 
           if(jwt(c) == nlevbed) then
-               if (.not. (zengdecker_2009_with_var_soil_thick)) then
-                wa(c)  = wa(c) + qcharge(c)  * dtime
-                zwt(c) = zwt(c) - (qcharge(c)  * dtime)/1000._r8/rous
-             end if
+            if (.not. (zengdecker_2009_with_var_soil_thick)) then
+              wa(c)  = wa(c) + qcharge(c)  * dtime
+              zwt(c) = zwt(c) - (qcharge(c)  * dtime)/1000._r8/rous
+            end if
           else
              !-- water table within soil layers 1-9  -------------------------------------
              ! try to raise water table to account for qcharge
@@ -899,7 +899,7 @@ contains
        ! perched water table code
        do fc = 1, num_hydrologyc
           c = filter_hydrologyc(fc)
-             nlevbed = nlev2bed(c)
+          nlevbed = nlev2bed(c)
 
           ! define frost table as first frozen layer with unfrozen layer above it
           if(t_soisno(c,1) > tfrz) then
@@ -909,10 +909,10 @@ contains
           endif
 
           do k=2, nlevbed
-             if (t_soisno(c,k-1) > tfrz .and. t_soisno(c,k) <= tfrz) then
-                k_frz=k
-                exit
-             endif
+            if (t_soisno(c,k-1) > tfrz .and. t_soisno(c,k) <= tfrz) then
+               k_frz=k
+               exit
+            endif
           enddo
 
           frost_table(c)=z(c,k_frz)
@@ -1166,7 +1166,7 @@ contains
 
        do fc = 1, num_hydrologyc
           c = filter_hydrologyc(fc)
-             nlevbed = nlev2bed(c)
+          nlevbed = nlev2bed(c)
           jwt(c) = nlevbed
           ! allow jwt to equal zero when zwt is in top layer
           do j = 1,nlevbed
@@ -1176,7 +1176,7 @@ contains
                 else
                    jwt(c) = j-1
                    exit
-            end if
+                end if
              end if
           enddo
        end do
@@ -1391,11 +1391,11 @@ contains
                 ! make sure baseflow isn't negative
                 rsub_top(c) = max(0._r8, rsub_top(c))
              else
-            if (jwt(c) == nlevbed .and. zengdecker_2009_with_var_soil_thick) then
+              if (jwt(c) == nlevbed .and. zengdecker_2009_with_var_soil_thick) then
                    rsub_top(c)    = 0._r8
                 else
                    rsub_top(c)    = imped * rsub_top_max* exp(-fff(c)*zwt(c))
-        end if
+              end if
              end if
 
              if (use_vsfm) rsub_top(c) = 0._r8
@@ -1407,28 +1407,28 @@ contains
 
              !--  water table is below the soil column  --------------------------------------
              if(jwt(c) == nlevbed) then
-            if (zengdecker_2009_with_var_soil_thick) then
-                if (-1._r8 * smp_l(c,nlevbed) < 0.5_r8 * dzmm(c,nlevbed)) then
+               if (zengdecker_2009_with_var_soil_thick) then
+                 if (-1._r8 * smp_l(c,nlevbed) < 0.5_r8 * dzmm(c,nlevbed)) then
                      zwt(c) = z(c,nlevbed) - (smp_l(c,nlevbed) / 1000._r8)
-           end if
-                   rsub_top(c) = imped * rsub_top_max * exp(-fff(c) * zwt(c))
-                   rsub_top_tot = - rsub_top(c) * dtime
-                   s_y = watsat(c,nlevbed) &
+                 end if
+                 rsub_top(c) = imped * rsub_top_max * exp(-fff(c) * zwt(c))
+                 rsub_top_tot = - rsub_top(c) * dtime
+                 s_y = watsat(c,nlevbed) &
                      * ( 1. - (1.+1.e3*zwt(c)/sucsat(c,nlevbed))**(-1./bsw(c,nlevbed)))
-                   s_y=max(s_y,0.02_r8)
-                   rsub_top_layer=max(rsub_top_tot,-(s_y*(zi(c,nlevbed) - zwt(c))*1.e3))
-                   rsub_top_layer=min(rsub_top_layer,0._r8)
-                   h2osoi_liq(c,nlevbed) = h2osoi_liq(c,nlevbed) + rsub_top_layer
-                   rsub_top_tot = rsub_top_tot - rsub_top_layer
-                   if (rsub_top_tot >= 0.) then
-                      zwt(c) = zwt(c) - rsub_top_layer/s_y/1000._r8
-                   else
-                      zwt(c) = zi(c,nlevbed)
-                   end if
-               if (rsub_top_tot < 0.) then
-                  rsub_top(c) = rsub_top(c) + rsub_top_tot / dtime
-                      rsub_top_tot = 0.
-                   end if
+                 s_y=max(s_y,0.02_r8)
+                 rsub_top_layer=max(rsub_top_tot,-(s_y*(zi(c,nlevbed) - zwt(c))*1.e3))
+                 rsub_top_layer=min(rsub_top_layer,0._r8)
+                 h2osoi_liq(c,nlevbed) = h2osoi_liq(c,nlevbed) + rsub_top_layer
+                 rsub_top_tot = rsub_top_tot - rsub_top_layer
+                 if (rsub_top_tot >= 0.) then
+                    zwt(c) = zwt(c) - rsub_top_layer/s_y/1000._r8
+                 else
+                    zwt(c) = zi(c,nlevbed)
+                 end if
+                 if (rsub_top_tot < 0.) then
+                   rsub_top(c) = rsub_top(c) + rsub_top_tot / dtime
+                   rsub_top_tot = 0.
+                 end if
                 else
                    wa(c)  = wa(c) - rsub_top(c) * dtime
                    zwt(c)     = zwt(c) + (rsub_top(c) * dtime)/1000._r8/rous
@@ -1570,8 +1570,8 @@ contains
 
        do fc = 1, num_hydrologyc
           c = filter_hydrologyc(fc)
-             nlevbed = nlev2bed(c)
-             do j = 1, nlevbed-1
+          nlevbed = nlev2bed(c)
+          do j = 1, nlevbed-1
              if (h2osoi_liq(c,j) < watmin) then
                 xs(c) = watmin - h2osoi_liq(c,j)
                 ! deepen water table if water is passed from below zwt layer
@@ -1589,8 +1589,8 @@ contains
        ! Get water for bottom layer from layers above if possible
        do fc = 1, num_hydrologyc
           c = filter_hydrologyc(fc)
-             nlevbed = nlev2bed(c)
-             j = nlevbed
+          nlevbed = nlev2bed(c)
+          j = nlevbed
           if (h2osoi_liq(c,j) < watmin) then
              xs(c) = watmin-h2osoi_liq(c,j)
              searchforwater: do i = nlevbed-1, 1, -1

--- a/components/elm/src/biogeophys/SoilHydrologyMod.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyMod.F90
@@ -337,10 +337,6 @@ contains
           nlev2bed             =>    col_pp%nlevbed              , & ! Input:  [integer  (:)   ]  number of layers to bedrock
           cgridcell            =>    col_pp%gridcell             , & ! Input:  [integer  (:)   ]  column's gridcell    
           wtgcell              =>    col_pp%wtgcell              , & ! Input:  [real(r8) (:)   ]  weight (relative to gridcell)
-          iwp_microrel         =>    col_pp%iwp_microrel         , & ! Input:  [real(r8) (:)   ]  ice wedge polygon microtopographic relief (m)
-          iwp_exclvol          =>    col_pp%iwp_exclvol          , & ! Input:  [real(r8) (:)   ]  ice wedge polygon excluded volume (m)
-          iwp_ddep             =>    col_pp%iwp_ddep             , & ! Input:  [real(r8) (:)   ]  ice wedge polygon depression depth (m)
-          iwp_subsidence       =>    col_pp%iwp_subsidence       , & ! Input:  [real(r8) (:)   ]  ice wedge polygon ground subsidence (m)
           meangradz            =>    col_pp%meangradz            , & ! Input:  [real(r8) (:)   ]  mean topographic gradient at the column level (unitless)
 
           t_soisno             =>    col_es%t_soisno             , & ! Input:  [real(r8) (:,:) ]  soil temperature (Kelvin)
@@ -355,6 +351,10 @@ contains
           h2osfc               =>    col_ws%h2osfc               , & ! Output: [real(r8) (:)   ]  surface water (mm)
           h2orof               =>    col_ws%h2orof               , & ! Output:  [real(r8) (:)   ]  floodplain inudntion volume (mm)
           frac_h2orof          =>    col_ws%frac_h2orof          , & ! Output:  [real(r8) (:)   ]  floodplain inudntion fraction (-)
+          iwp_microrel         =>    col_ws%iwp_microrel         , & ! Input:  [real(r8) (:)   ]  ice wedge polygon microtopographic relief (m)
+          iwp_exclvol          =>    col_ws%iwp_exclvol          , & ! Input:  [real(r8) (:)   ]  ice wedge polygon excluded volume (m)
+          iwp_ddep             =>    col_ws%iwp_ddep             , & ! Input:  [real(r8) (:)   ]  ice wedge polygon depression depth (m)
+          iwp_subsidence       =>    col_ws%iwp_subsidence       , & ! Input:  [real(r8) (:)   ]  ice wedge polygon ground subsidence (m)
 
           qflx_ev_soil         =>    col_wf%qflx_ev_soil         , & ! Input:  [real(r8) (:)   ]  evaporation flux from soil (W/m**2) [+ to atm]
           qflx_evap_soi        =>    col_wf%qflx_evap_soi        , & ! Input:  [real(r8) (:)   ]  ground surface evaporation rate (mm H2O/s) [+]

--- a/components/elm/src/biogeophys/SoilHydrologyMod.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyMod.F90
@@ -530,7 +530,7 @@ contains
              if (lun_pp%ispolygon(col_pp%landunit(c))) then
                 vdep = (2_r8*iwp_exclvol(c) - iwp_microrel(c)) * (iwp_ddep(c)/iwp_microrel(c))**3_r8 &
                        + (2_r8*iwp_microrel(c) - 3_r8*iwp_exclvol(c)) * (iwp_ddep(c)/iwp_microrel(c))**2_r8
-                phi_eff = min(iwp_subsidence(c), 0.4)  !fix this variable when available to pull from alt calculations
+                phi_eff = min(iwp_subsidence(c), 0.4_r8)  !fix this variable when available to pull from alt calculations
                 swc = h2osfc(c)/1000_r8 ! convert to m
                 
                 if (swc >= vdep) then

--- a/components/elm/src/biogeophys/WaterStateType.F90
+++ b/components/elm/src/biogeophys/WaterStateType.F90
@@ -35,7 +35,8 @@ module WaterstateType
      real(r8), pointer :: bw_col                 (:,:) ! col partial density of water in the snow pack (ice + liquid) [kg/m3] 
      real(r8), pointer :: finundated_col         (:)   ! fraction of column that is inundated, this is for bgc caclulation in betr
      real(r8), pointer :: h2osoi_tend_tsl_col    (:)   ! col moisture tendency due to vertical movement at topmost layer (m3/m3/s)
- 
+     real(r8), pointer :: excess_ice             (:,:) ! excess ground ice in polygonal tundra areas [kg/m2]
+
      real(r8), pointer :: rhvap_soi_col          (:,:)
      real(r8), pointer :: rho_vap_col            (:,:)
      real(r8), pointer :: smp_l_col              (:,:) ! col liquid phase soil matric potential, mm
@@ -211,6 +212,7 @@ contains
     if (use_fan) then
        allocate(this%h2osoi_tend_tsl_col(begc:endc))                      ; this%h2osoi_tend_tsl_col    (:)   = nan
     end if
+    allocate(this%excess_ice             (begc:endc, 1:nlevgrnd))         ; this%excess_ice             (:,:) = nan
 
     allocate(this%h2osno_col             (begc:endc))                     ; this%h2osno_col             (:)   = nan   
     allocate(this%h2osno_old_col         (begc:endc))                     ; this%h2osno_old_col         (:)   = nan   

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -143,7 +143,8 @@ module ColumnDataType
     real(r8), pointer :: snow_persistence   (:)   => null() ! length of time that ground has had non-zero snow thickness (sec)
     real(r8), pointer :: snw_rds_top        (:)   => null() ! snow grain radius (top layer)  (m^-6, microns)
     logical , pointer :: do_capsnow         (:)   => null() ! true => do snow capping
-    real(r8), pointer :: h2osoi_tend_tsl_col(:)   => null() ! col moisture tendency due to vertical movement at topmost layer (m3/m3/s) 
+    real(r8), pointer :: h2osoi_tend_tsl_col(:)   => null() ! col moisture tendency due to vertical movement at topmost layer (m3/m3/s)
+    real(r8), pointer :: excess_ice         (:)   => null() ! NGEE-Arctic: tracking excess ground ice
     ! Area fractions
     real(r8), pointer :: frac_sno           (:)   => null() ! fraction of ground covered by snow (0 to 1)
     real(r8), pointer :: frac_sno_eff       (:)   => null() ! fraction of ground covered by snow (0 to 1)
@@ -1417,6 +1418,7 @@ contains
     if (use_fan) then
        allocate(this%h2osoi_tend_tsl_col(begc:endc))                  ; this%h2osoi_tend_tsl_col(:)   = spval
     end if
+    allocate(this%excess_ice         (begc:endc))                     ; this%excess_ice         (:)   = spval
     allocate(this%snw_rds_top        (begc:endc))                     ; this%snw_rds_top        (:)   = spval
     allocate(this%do_capsnow         (begc:endc))
     allocate(this%frac_sno           (begc:endc))                     ; this%frac_sno           (:)   = spval
@@ -1563,7 +1565,12 @@ contains
          ptr_col=this%h2osoi_tend_tsl_col, l2g_scale_type='veg', &
          default='inactive')
     end if
- 
+
+    this%excess_ice(begc:endc) = spval
+    call hist_addfld1d (fname='EXCESS_ICE', units = 'kg/m2', &
+         avgflag='A', long_name='Excess ground ice', &
+         ptr_col=this$excess_ice, l2g_scale_type='veg') ! <- RPF: should this be natveg?
+
     this%frac_sno(begc:endc) = spval
     call hist_addfld1d (fname='FSNO',  units='1',  &
          avgflag='A', long_name='fraction of ground covered by snow', &
@@ -1911,6 +1918,11 @@ contains
     if (flag=='read' .and. .not. readvar) then
          this%snow_persistence(:) = 0.0_r8
     end if
+
+    call restartvar(ncid=ncid, flag=flag, varname='EXCESS_ICE', xtype=ncd_double, &
+         dim1name='column', &
+         long_name='excess ground ice', units='kg/m2', &
+         interpinic_flag='interp', readvar=readvar, data=this%excess_ice)
 
     call restartvar(ncid=ncid, flag=flag, varname='frac_sno', xtype=ncd_double,  &
          dim1name='column', &

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -35,7 +35,7 @@ module ColumnDataType
   use soilorder_varcon, only : smax, ks_sorption
   use elm_time_manager, only : is_restart, get_nstep
   use elm_time_manager, only : is_first_step, get_step_size, is_first_restart_step
-  use landunit_varcon , only : istice, istwet, istsoil, istdlak, istcrop, istice_mec
+  use landunit_varcon , only : istice, istwet, istsoil, istdlak, istcrop, istice_mec, istlowcenpoly, isthighcenpoly
   use column_varcon   , only : icol_road_perv, icol_road_imperv, icol_roof, icol_sunwall, icol_shadewall
   use histFileMod     , only : hist_addfld1d, hist_addfld2d, no_snow_normal
   use histFileMod     , only : hist_addfld_decomp
@@ -110,7 +110,6 @@ module ColumnDataType
     real(r8), pointer :: h2osoi_liq         (:,:) => null() ! liquid water (-nlevsno+1:nlevgrnd) (kg/m2)
     real(r8), pointer :: h2osoi_ice         (:,:) => null() ! ice lens (-nlevsno+1:nlevgrnd) (kg/m2)
     real(r8), pointer :: h2osoi_vol         (:,:) => null() ! volumetric soil water (0<=h2osoi_vol<=watsat) (1:nlevgrnd) (m3/m3)
-    real(r8), pointer :: excess_ice         (:,:) => null() ! NGEE Arctic: excess ground ice in column (1:nlevgrnd) (0 to 1)
     real(r8), pointer :: h2osfc             (:)   => null() ! surface water (kg/m2)
     real(r8), pointer :: h2ocan             (:)   => null() ! canopy water integrated to column (kg/m2)
     real(r8), pointer :: total_plant_stored_h2o(:)=> null() ! total water in plants (kg/m2)
@@ -170,11 +169,13 @@ module ColumnDataType
     real(r8), pointer :: vsfm_soilp_col_1d  (:)   => null() ! 1D soil liquid pressure from VSFM [Pa]
     real(r8), pointer :: h2orof             (:)   => null() ! floodplain inundation volume received from rof (mm)
     real(r8), pointer :: frac_h2orof        (:)   => null() ! floodplain inundation fraction received from rof (-)
-   ! polygonal tundra
-    real(r8), pointer :: iwp_microrel  (:) => null() ! ice wedge polygon microtopographic relief (m)
-    real(r8), pointer :: iwp_exclvol   (:) => null() ! ice wedge polygon excluded volume (m)
-    real(r8), pointer :: iwp_ddep      (:) => null() ! ice wedge polygon depression depth (m)
-    real(r8), pointer :: iwp_subsidence(:) => null() ! ice wedge polygon ground subsidence (m)
+   ! polygonal tundra (NGEE Arctic IM1)
+    real(r8), pointer :: iwp_microrel     (:) => null() ! ice wedge polygon microtopographic relief (m)
+    real(r8), pointer :: iwp_exclvol      (:) => null() ! ice wedge polygon excluded volume (m)
+    real(r8), pointer :: iwp_ddep         (:) => null() ! ice wedge polygon depression depth (m)
+    real(r8), pointer :: iwp_subsidence   (:) => null() ! ice wedge polygon ground subsidence (m)
+    real(r8), pointer :: excess_ice     (:,:) => null() ! excess ground ice in column (1:nlevgrnd) (0 to 1)
+    real(r8), pointer :: frac_melted    (:,:) => null() ! fraction of layer that has ever thawed (for tracking excess ice removal) (0 to 1)
 
   contains
     procedure, public :: Init    => col_ws_init
@@ -1396,7 +1397,6 @@ contains
     allocate(this%h2osoi_liq         (begc:endc,-nlevsno+1:nlevgrnd)) ; this%h2osoi_liq         (:,:) = spval
     allocate(this%h2osoi_ice         (begc:endc,-nlevsno+1:nlevgrnd)) ; this%h2osoi_ice         (:,:) = spval
     allocate(this%h2osoi_vol         (begc:endc, 1:nlevgrnd))         ; this%h2osoi_vol         (:,:) = spval
-    allocate(this%excess_ice         (begc:endc, 1:nlevgrnd))         ; this%excess_ice         (:,:) = spval
     allocate(this%h2osfc             (begc:endc))                     ; this%h2osfc             (:)   = spval
     allocate(this%h2ocan             (begc:endc))                     ; this%h2ocan             (:)   = spval
     allocate(this%wslake_col         (begc:endc))                     ; this%wslake_col         (:)   = spval
@@ -1454,11 +1454,15 @@ contains
     allocate(this%vsfm_soilp_col_1d  (ncells))                        ; this%vsfm_soilp_col_1d  (:)   = spval
     allocate(this%h2orof             (begc:endc))                     ; this%h2orof             (:)   = spval
     allocate(this%frac_h2orof        (begc:endc))                     ; this%frac_h2orof        (:)   = spval
-    ! polygonal tundra/ice wedge polygons:
-    allocate(this%iwp_microrel       (begc:endc))                   ; this%iwp_microrel  (:) = spval
-    allocate(this%iwp_exclvol        (begc:endc))                   ; this%iwp_exclvol   (:) = spval
-    allocate(this%iwp_ddep           (begc:endc))                   ; this%iwp_ddep      (:) = spval
-    allocate(this%iwp_subsidence     (begc:endc))                   ; this%iwp_subsidence(:) = spval
+    if (use_polygonal_tundra) then
+      ! polygonal tundra/ice wedge polygons:
+      allocate(this%iwp_microrel       (begc:endc))                   ; this%iwp_microrel     (:) = spval
+      allocate(this%iwp_exclvol        (begc:endc))                   ; this%iwp_exclvol      (:) = spval
+      allocate(this%iwp_ddep           (begc:endc))                   ; this%iwp_ddep         (:) = spval
+      allocate(this%iwp_subsidence     (begc:endc))                   ; this%iwp_subsidence   (:) = spval
+      allocate(this%frac_melted        (begc:endc,1:nlevgrnd))        ; this%frac_melted    (:,:) = spval
+      allocate(this%excess_ice         (begc:endc,1:nlevgrnd))        ; this%excess_ice     (:,:) = spval
+    end if
 
     !-----------------------------------------------------------------------
     ! initialize history fields for select members of col_ws
@@ -1494,19 +1498,17 @@ contains
          avgflag='A', long_name='soil ice (ice landunits only)', &
          ptr_col=this%h2osoi_ice, l2g_scale_type='ice')
 
-    ! RPF - polygonal tundra vars
-    this%excess_ice(begc:endc, :) = spval
     if (use_polygonal_tundra) then
+      this%iwp_subsidence(begc:endc)    = spval
+      this%iwp_ddep(begc:endc)          = spval
+      this%iwp_exclvol(begc:endc)       = spval
+      this%iwp_microrel(begc:endc)      = spval
+      this%frac_melted(begc:endc,:)     = spval
+      this%excess_ice(begc:endc,:)      = spval
+
       call hist_addfld2d (fname='EXCESS_ICE', units = '1', type2d='levgrnd', &
            avgflag='A', long_name='Excess ground ice (0 to 1)', &
            ptr_col=this%excess_ice, l2g_scale_type='veg') ! <- RPF: should this be natveg?
-    end if
-
-    this%iwp_subsidence(begc:endc) = spval
-    this%iwp_ddep(begc:endc)       = spval
-    this%iwp_exclvol(begc:endc)    = spval
-    this%iwp_microrel(begc:endc)   = spval
-    if (use_polygonal_tundra) then
       call hist_addfld1d (fname="SUBSIDENCE", units='m', avgflag='A', &
             long_name='ground subsidence (m)', ptr_col=this%iwp_subsidence)
       call hist_addfld1d (fname="DEPRESS_DEPTH", units='m', avgflag='A', &
@@ -1516,6 +1518,9 @@ contains
             ptr_col=this%iwp_exclvol)
       call hist_addfld1d (fname="MICROREL", units='m', avgflag='A', &
             long_name='microtopographic relief (m)', ptr_col=this%iwp_microrel)
+      call hist_addfld2d (fname="FRAC_MELTED", units='-', type2d='levgrnd', &
+            avgflag='A', long_name='fraction of layer that has melted (-)', &
+            ptr_col=this%frac_melted, l2g_scale_type='veg')
     endif
     !/polygonal tundra
 
@@ -1679,6 +1684,7 @@ contains
        this%h2orof(c)                 = 0._r8
        this%frac_h2orof(c)            = 0._r8
        this%iwp_subsidence(c)         = 0._r8
+       this%frac_melted(c,:)          = 0._r8
 
        if (lun_pp%urbpoi(l)) then
           ! From Bonan 1996 (LSM technical note)
@@ -1731,13 +1737,16 @@ contains
                 if (j > nlevbed) then
                    this%h2osoi_vol(c,j) = 0.0_r8
                 else
-		               if (use_fates .or. use_hydrstress) then
+		             if (use_fates .or. use_hydrstress) then
                       this%h2osoi_vol(c,j) = 0.70_r8*watsat_input(c,j) !0.15_r8 to avoid very dry conditions that cause errors in FATES
                    else if (use_arctic_init) then
-                     this%h2osoi_vol(c,j) = watsat_input(c,j) ! start saturated for arctic
+                      this%h2osoi_vol(c,j) = watsat_input(c,j) ! start saturated for arctic
                    else
                       this%h2osoi_vol(c,j) = 0.15_r8
                    endif
+                   if (use_polygonal_tundra) then
+                     this%frac_melted(c,j) = 0._r8
+                   end if
                 endif
              end do
           else if (lun_pp%urbpoi(l)) then
@@ -1838,23 +1847,14 @@ contains
              this%h2osoi_ice(c,j) = 0._r8
              this%h2osoi_liq(c,j) = col_pp%dz(c,j)*denh2o*this%h2osoi_vol(c,j)
           endif
-          ! RPF 240713 - notes from Chuck: initialize all to 0.36_r8
-          this%excess_ice(c,j) = 0.36_r8
-          ! RPF - to do: a) apply to only polygonal ground
-          ! b) pull in ALT information to get starting point right.
-          ! for now, assuming no excess ice in top meter, 0.5 for 1-4 m,
-          ! 0.2 below 4 m. Also: need to check signs!
-          !if (col_pp%z(c,j) > -1._r8) then
-          !  this%excess_ice(c,j) = 0._r8
-          !else if (col_pp%z(c,j) > -4._r8 .and. col_pp%z(c,j) < -1._r8) then
-          !  this%excess_ice(c,j) = 0.5_r8
-          !else
-          !  this%excess_ice(c,j) = 0.2_r8
-          !end if
        end do
 
        this%h2osoi_liq_old(c,:) = this%h2osoi_liq(c,:)
        this%h2osoi_ice_old(c,:) = this%h2osoi_ice(c,:)
+       if (use_polygonal_tundra) then
+         ! RPF 240713 - notes from Chuck Abolt: initialize all to 0.36_r8
+         this%excess_ice(c,:) = 0.36_r8
+       end if
     end do
 
   end subroutine col_ws_init
@@ -1929,6 +1929,10 @@ contains
            dim1name='column', &
            long_name='microtopographic relief', units='m', &
            interpinic_flag='interp', readvar=readvar, data=this%iwp_microrel)
+      call restartvar(ncid=ncid, flag=flag, varname='FRAC_MELTED', xtype=ncd_double, &
+           dim1name='column', dim2name='levgrnd', switchdim=.true., &
+           long_name='fraction of layer that has ever melted', units='-', &
+           interpinic_flag='interp', readvar=readvar, data=this%frac_melted)
     end if
 
     call restartvar(ncid=ncid, flag=flag, varname='SOILP', xtype=ncd_double,  &

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -1683,8 +1683,6 @@ contains
        this%frac_h2osfc_act(c)        = 0._r8
        this%h2orof(c)                 = 0._r8
        this%frac_h2orof(c)            = 0._r8
-       this%iwp_subsidence(c)         = 0._r8
-       this%frac_melted(c,:)          = 0._r8
 
        if (lun_pp%urbpoi(l)) then
           ! From Bonan 1996 (LSM technical note)
@@ -1854,6 +1852,8 @@ contains
        if (use_polygonal_tundra) then
          ! RPF 240713 - notes from Chuck Abolt: initialize all to 0.36_r8
          this%excess_ice(c,:) = 0.36_r8
+         this%iwp_subsidence(c) = 0._r8
+         this%frac_melted(c,:)  = 0._r8
        end if
     end do
 

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -1087,7 +1087,7 @@ contains
     !
     ! !USES:
     use landunit_varcon, only : istice, istwet, istsoil, istdlak, istice_mec
-    use elm_varctl     , only : iulog, use_cn, use_vancouver, use_mexicocity
+    use elm_varctl     , only : iulog, use_cn, use_vancouver, use_mexicocity, use_arctic_init
     use column_varcon  , only : icol_road_perv, icol_road_imperv, icol_roof, icol_sunwall, icol_shadewall
     use UrbanParamsType, only : urbanparams_vars
     !
@@ -1222,7 +1222,7 @@ contains
        ! Below snow temperatures - nonlake points (lake points are set below)
        if (.not. lun_pp%lakpoi(l)) then
 
-          if (lun_pp%itype(l)==istice .or. lun_pp%itype(l)==istice_mec) then
+          if (lun_pp%itype(l)==istice .or. lun_pp%itype(l)==istice_mec .or. use_arctic_init) then
              this%t_soisno(c,1:nlevgrnd) = 250._r8
 
           else if (lun_pp%itype(l) == istwet) then
@@ -1364,7 +1364,7 @@ contains
   !------------------------------------------------------------------------
   subroutine col_ws_init(this, begc, endc, h2osno_input, snow_depth_input, watsat_input)
     !
-    use elm_varctl  , only : use_lake_wat_storage
+    use elm_varctl  , only : use_lake_wat_storage, use_arctic_init
     ! !ARGUMENTS:
     class(column_water_state) :: this
     integer , intent(in)      :: begc,endc
@@ -1706,6 +1706,8 @@ contains
                 else
 		               if (use_fates .or. use_hydrstress) then
                       this%h2osoi_vol(c,j) = 0.70_r8*watsat_input(c,j) !0.15_r8 to avoid very dry conditions that cause errors in FATES
+                   else if (use_arctic_init) then
+                     this%h2osoi_vol(c,j) = watsat_input(c,j) ! start saturated for arctic
                    else
                       this%h2osoi_vol(c,j) = 0.15_r8
                    endif

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -48,7 +48,8 @@ module ColumnDataType
   use CNDecompCascadeConType , only : decomp_cascade_con
   use ColumnType      , only : col_pp
   use LandunitType    , only : lun_pp
-  use timeInfoMod , only : nstep_mod 
+  use GridcellType    , only : grc_pp
+  use timeInfoMod , only : nstep_mod
   !
   ! !PUBLIC TYPES:
   implicit none
@@ -1102,7 +1103,7 @@ contains
     !------------------------------------------------------------------------
     !
     ! !LOCAL VARIABLES:
-    integer           :: c,l,j                        ! indices
+    integer           :: c,l,j,g                        ! indices
     real(r8), pointer :: data2dptr(:,:), data1dptr(:) ! temp. pointers for slicing larger arrays
 
     !------------------------------------------------------------------------------
@@ -1227,8 +1228,13 @@ contains
        ! Below snow temperatures - nonlake points (lake points are set below)
        if (.not. lun_pp%lakpoi(l)) then
 
-          if (lun_pp%itype(l)==istice .or. lun_pp%itype(l)==istice_mec .or. use_arctic_init) then
-             this%t_soisno(c,1:nlevgrnd) = 250._r8
+          if (lun_pp%itype(l)==istice .or. lun_pp%itype(l)==istice_mec) then
+            if (use_arctic_init) then
+              g = lun_pp%gridcell(l)
+              this%t_soisnow(c,1:nlevgrnd) = 250._r8 + 40._r8 * cos(grc_pp%lat(g)) ! vary between 250 and 290 based on cos(lat)
+            else
+              this%t_soisno(c,1:nlevgrnd) = 250._r8
+            end if
 
           else if (lun_pp%itype(l) == istwet) then
              this%t_soisno(c,1:nlevgrnd) = 277._r8
@@ -1390,17 +1396,9 @@ contains
     allocate(this%h2osoi_liq         (begc:endc,-nlevsno+1:nlevgrnd)) ; this%h2osoi_liq         (:,:) = spval
     allocate(this%h2osoi_ice         (begc:endc,-nlevsno+1:nlevgrnd)) ; this%h2osoi_ice         (:,:) = spval
     allocate(this%h2osoi_vol         (begc:endc, 1:nlevgrnd))         ; this%h2osoi_vol         (:,:) = spval
-<<<<<<< HEAD
-    allocate(this%h2osfc             (begc:endc))                     ; this%h2osfc             (:)   = spval   
-    allocate(this%h2ocan             (begc:endc))                     ; this%h2ocan             (:)   = spval 
-||||||| parent of 88480f7699 (Update excess_ice from single column value to depth varying)
-    allocate(this%h2osfc             (begc:endc))                     ; this%h2osfc             (:)   = spval
-    allocate(this%h2ocan             (begc:endc))                     ; this%h2ocan             (:)   = spval
-=======
     allocate(this%excess_ice         (begc:endc, 1:nlevgrnd))         ; this%excess_ice         (:,:) = spval
     allocate(this%h2osfc             (begc:endc))                     ; this%h2osfc             (:)   = spval
     allocate(this%h2ocan             (begc:endc))                     ; this%h2ocan             (:)   = spval
->>>>>>> 88480f7699 (Update excess_ice from single column value to depth varying)
     allocate(this%wslake_col         (begc:endc))                     ; this%wslake_col         (:)   = spval
     allocate(this%total_plant_stored_h2o(begc:endc))                  ; this%total_plant_stored_h2o(:)= spval  
     allocate(this%h2osoi_liqvol      (begc:endc,-nlevsno+1:nlevgrnd)) ; this%h2osoi_liqvol      (:,:) = spval

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -169,6 +169,11 @@ module ColumnDataType
     real(r8), pointer :: vsfm_soilp_col_1d  (:)   => null() ! 1D soil liquid pressure from VSFM [Pa]
     real(r8), pointer :: h2orof             (:)   => null() ! floodplain inundation volume received from rof (mm)
     real(r8), pointer :: frac_h2orof        (:)   => null() ! floodplain inundation fraction received from rof (-)
+   ! polygonal tundra
+    real(r8), pointer :: iwp_microrel  (:) => null() ! ice wedge polygon microtopographic relief (m)
+    real(r8), pointer :: iwp_exclvol   (:) => null() ! ice wedge polygon excluded volume (m)
+    real(r8), pointer :: iwp_ddep      (:) => null() ! ice wedge polygon depression depth (m)
+    real(r8), pointer :: iwp_subsidence(:) => null() ! ice wedge polygon ground subsidence (m)
 
   contains
     procedure, public :: Init    => col_ws_init
@@ -1451,6 +1456,11 @@ contains
     allocate(this%vsfm_soilp_col_1d  (ncells))                        ; this%vsfm_soilp_col_1d  (:)   = spval
     allocate(this%h2orof             (begc:endc))                     ; this%h2orof             (:)   = spval
     allocate(this%frac_h2orof        (begc:endc))                     ; this%frac_h2orof        (:)   = spval
+    ! polygonal tundra/ice wedge polygons:
+    allocate(this%iwp_microrel       (begc:endc))                   ; this%iwp_microrel  (:) = spval
+    allocate(this%iwp_exclvol        (begc:endc))                   ; this%iwp_exclvol   (:) = spval
+    allocate(this%iwp_ddep           (begc:endc))                   ; this%iwp_ddep      (:) = spval
+    allocate(this%iwp_subsidence     (begc:endc))                   ; this%iwp_subsidence(:) = spval
 
     !-----------------------------------------------------------------------
     ! initialize history fields for select members of col_ws
@@ -1486,12 +1496,30 @@ contains
          avgflag='A', long_name='soil ice (ice landunits only)', &
          ptr_col=this%h2osoi_ice, l2g_scale_type='ice')
 
+    ! RPF - polygonal tundra vars
     this%excess_ice(begc:endc, :) = spval
     if (use_polygonal_tundra) then
       call hist_addfld2d (fname='EXCESS_ICE', units = '1', type2d='levgrnd', &
            avgflag='A', long_name='Excess ground ice (0 to 1)', &
            ptr_col=this%excess_ice, l2g_scale_type='veg') ! <- RPF: should this be natveg?
     end if
+
+    this%iwp_subsidence(begc:endc) = spval
+    this%iwp_ddep(begc:endc)       = spval
+    this%iwp_exclvol(begc:endc)    = spval
+    this%iwp_microrel(begc:endc)   = spval
+    if (use_polygonal_tundra) then
+      call hist_addfld1d (fname="SUBSIDENCE", units='m', avgflag='A', &
+            long_name='ground subsidence (m)', ptr_col=this%iwp_subsidence)
+      call hist_addfld1d (fname="DEPRESS_DEPTH", units='m', avgflag='A', &
+            long_name='microtopographic depression depth (m)', ptr_col=this%iwp_ddep)
+      call hist_addfld1d (fname="EXCLUDED_VOL", units='m', avgflag='A', &
+            long_name='volume of soil above lowest point on IWP surface, normalized by polygon area', &
+            ptr_col=this%iwp_ddep)
+      call hist_addfld1d (fname="MICROREL", units='m', avgflag='A', &
+            long_name='microtopographic relief (m)', ptr_col=this%iwp_ddep)
+    endif
+    !/polygonal tundra
 
     this%h2osfc(begc:endc) = spval
      call hist_addfld1d (fname='H2OSFC',  units='mm',  &
@@ -1886,6 +1914,22 @@ contains
            dim1name='column', dim2name='levgrnd', switchdim=.true., &
            long_name='excess ground ice (0 to 1)', units='1', &
            interpinic_flag='interp', readvar=readvar, data=this%excess_ice)
+      call restartvar(ncid=ncid, flag=flag, varname='SUBSIDENCE', xtype=ncd_double, &
+           dim1name='column', &
+           long_name='ground subsidence', units='m', &
+           interpinic_flag='interp', readvar=readvar, data=this%iwp_subsidence)
+      call restartvar(ncid=ncid, flag=flag, varname='DEPRESS_DEPTH', xtype=ncd_double, &
+           dim1name='column', &
+           long_name='microtopographic depression depth', units='m', &
+           interpinic_flag='interp', readvar=readvar, data=this%iwp_ddep)
+      call restartvar(ncid=ncid, flag=flag, varname='EXCLUDED_VOL', xtype=ncd_double, &
+           dim1name='column', &
+           long_name='volume of soil above lowest point on IWP surface, normalized by polygon area', units='m3', &
+           interpinic_flag='interp', readvar=readvar, data=this%iwp_exclvol)
+      call restartvar(ncid=ncid, flag=flag, varname='MICROREL', xtype=ncd_double, &
+           dim1name='column', &
+           long_name='microtopographic relief', units='m', &
+           interpinic_flag='interp', readvar=readvar, data=this%iwp_microrel)
     end if
 
     call restartvar(ncid=ncid, flag=flag, varname='SOILP', xtype=ncd_double,  &

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -28,7 +28,7 @@ module ColumnDataType
   use elm_varctl      , only : hist_wrtch4diag, use_century_decomp
   use elm_varctl      , only : get_carbontag, override_bgc_restart_mismatch_dump
   use elm_varctl      , only : pf_hmode, nu_com
-  use elm_varctl      , only : use_extrasnowlayers
+  use elm_varctl      , only : use_extrasnowlayers, use_polygonal_tundra
   use elm_varctl      , only : use_fan
   use ch4varcon       , only : allowlakeprod
   use pftvarcon       , only : VMAX_MINSURF_P_vr, KM_MINSURF_P_vr, pinit_beta1, pinit_beta2
@@ -1487,9 +1487,11 @@ contains
          ptr_col=this%h2osoi_ice, l2g_scale_type='ice')
 
     this%excess_ice(begc:endc, :) = spval
-    call hist_addfld2d (fname='EXCESS_ICE', units = '1', type2d='levgrnd', &
-         avgflag='A', long_name='Excess ground ice (0 to 1)', &
-         ptr_col=this%excess_ice, l2g_scale_type='veg') ! <- RPF: should this be natveg?
+    if (use_polygonal_tundra) then
+      call hist_addfld2d (fname='EXCESS_ICE', units = '1', type2d='levgrnd', &
+           avgflag='A', long_name='Excess ground ice (0 to 1)', &
+           ptr_col=this%excess_ice, l2g_scale_type='veg') ! <- RPF: should this be natveg?
+    end if
 
     this%h2osfc(begc:endc) = spval
      call hist_addfld1d (fname='H2OSFC',  units='mm',  &
@@ -1807,17 +1809,19 @@ contains
              this%h2osoi_ice(c,j) = 0._r8
              this%h2osoi_liq(c,j) = col_pp%dz(c,j)*denh2o*this%h2osoi_vol(c,j)
           endif
+          ! RPF 240713 - notes from Chuck: initialize all to 0.36_r8
+          this%excess_ice(c,j) = 0.36_r8
           ! RPF - to do: a) apply to only polygonal ground
           ! b) pull in ALT information to get starting point right.
           ! for now, assuming no excess ice in top meter, 0.5 for 1-4 m,
           ! 0.2 below 4 m. Also: need to check signs!
-          if (col_pp%z(c,j) > -1._r8) then
-            this%excess_ice(c,j) = 0._r8
-          else if (col_pp%z(c,j) > -4._r8 .and. col_pp%z(c,j) < -1._r8) then
-            this%excess_ice(c,j) = 0.5_r8
-          else
-            this%excess_ice(c,j) = 0.2_r8
-          end if
+          !if (col_pp%z(c,j) > -1._r8) then
+          !  this%excess_ice(c,j) = 0._r8
+          !else if (col_pp%z(c,j) > -4._r8 .and. col_pp%z(c,j) < -1._r8) then
+          !  this%excess_ice(c,j) = 0.5_r8
+          !else
+          !  this%excess_ice(c,j) = 0.2_r8
+          !end if
        end do
 
        this%h2osoi_liq_old(c,:) = this%h2osoi_liq(c,:)
@@ -1875,10 +1879,12 @@ contains
          long_name='ice lens', units='kg/m2', &
          interpinic_flag='interp', readvar=readvar, data=this%h2osoi_ice)
 
-    call restartvar(ncid=ncid, flag=flag, varname='EXCESS_ICE', xtype=ncd_double, &
-         dim1name='column', dim2name='levgrnd', switchdim=.true., &
-         long_name='excess ground ice (0 to 1)', units='1', &
-         interpinic_flag='interp', readvar=readvar, data=this%excess_ice)
+    if (use_polygonal_tundra) then
+      call restartvar(ncid=ncid, flag=flag, varname='EXCESS_ICE', xtype=ncd_double, &
+           dim1name='column', dim2name='levgrnd', switchdim=.true., &
+           long_name='excess ground ice (0 to 1)', units='1', &
+           interpinic_flag='interp', readvar=readvar, data=this%excess_ice)
+    end if
 
     call restartvar(ncid=ncid, flag=flag, varname='SOILP', xtype=ncd_double,  &
          dim1name='column', dim2name='levgrnd', switchdim=.true., &

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -1229,12 +1229,7 @@ contains
        if (.not. lun_pp%lakpoi(l)) then
 
           if (lun_pp%itype(l)==istice .or. lun_pp%itype(l)==istice_mec) then
-            if (use_arctic_init) then
-              g = lun_pp%gridcell(l)
-              this%t_soisnow(c,1:nlevgrnd) = 250._r8 + 40._r8 * cos(grc_pp%lat(g)) ! vary between 250 and 290 based on cos(lat)
-            else
-              this%t_soisno(c,1:nlevgrnd) = 250._r8
-            end if
+             this%t_soisno(c,1:nlevgrnd) = 250._r8
 
           else if (lun_pp%itype(l) == istwet) then
              this%t_soisno(c,1:nlevgrnd) = 277._r8
@@ -1279,7 +1274,12 @@ contains
                 end if
              end if
           else
-             this%t_soisno(c,1:nlevgrnd) = 274._r8
+            if (use_arctic_init) then
+              g = lun_pp%gridcell(l)
+              this%t_soisno(c,1:nlevgrnd) = 250._r8 + 40._r8 * cos(grc_pp%lat(g)) ! vary between 250 and 290 based on cos(lat)
+            else
+              this%t_soisno(c,1:nlevgrnd) = 274._r8
+            end if
           endif
           this%t_grnd(c) = this%t_soisno(c,snl(c)+1)
        endif

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -1567,9 +1567,9 @@ contains
     end if
 
     this%excess_ice(begc:endc) = spval
-    call hist_addfld1d (fname='EXCESS_ICE', units = 'kg/m2', &
-         avgflag='A', long_name='Excess ground ice', &
-         ptr_col=this$excess_ice, l2g_scale_type='veg') ! <- RPF: should this be natveg?
+    call hist_addfld1d (fname='EXCESS_ICE', units = '1', &
+         avgflag='A', long_name='Excess ground ice (0 to 1)', &
+         ptr_col=this%excess_ice, l2g_scale_type='veg') ! <- RPF: should this be natveg?
 
     this%frac_sno(begc:endc) = spval
     call hist_addfld1d (fname='FSNO',  units='1',  &
@@ -1642,6 +1642,7 @@ contains
        this%frac_h2osfc_act(c)        = 0._r8
        this%h2orof(c)                 = 0._r8
        this%frac_h2orof(c)            = 0._r8
+       this%excess_ice(c)             = 0.5_r8
 
        if (lun_pp%urbpoi(l)) then
           ! From Bonan 1996 (LSM technical note)
@@ -1921,7 +1922,7 @@ contains
 
     call restartvar(ncid=ncid, flag=flag, varname='EXCESS_ICE', xtype=ncd_double, &
          dim1name='column', &
-         long_name='excess ground ice', units='kg/m2', &
+         long_name='excess ground ice (0 to 1)', units='1', &
          interpinic_flag='interp', readvar=readvar, data=this%excess_ice)
 
     call restartvar(ncid=ncid, flag=flag, varname='frac_sno', xtype=ncd_double,  &

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -109,6 +109,7 @@ module ColumnDataType
     real(r8), pointer :: h2osoi_liq         (:,:) => null() ! liquid water (-nlevsno+1:nlevgrnd) (kg/m2)
     real(r8), pointer :: h2osoi_ice         (:,:) => null() ! ice lens (-nlevsno+1:nlevgrnd) (kg/m2)
     real(r8), pointer :: h2osoi_vol         (:,:) => null() ! volumetric soil water (0<=h2osoi_vol<=watsat) (1:nlevgrnd) (m3/m3)
+    real(r8), pointer :: excess_ice         (:,:) => null() ! NGEE Arctic: excess ground ice in column (1:nlevgrnd) (0 to 1)
     real(r8), pointer :: h2osfc             (:)   => null() ! surface water (kg/m2)
     real(r8), pointer :: h2ocan             (:)   => null() ! canopy water integrated to column (kg/m2)
     real(r8), pointer :: total_plant_stored_h2o(:)=> null() ! total water in plants (kg/m2)
@@ -144,7 +145,6 @@ module ColumnDataType
     real(r8), pointer :: snw_rds_top        (:)   => null() ! snow grain radius (top layer)  (m^-6, microns)
     logical , pointer :: do_capsnow         (:)   => null() ! true => do snow capping
     real(r8), pointer :: h2osoi_tend_tsl_col(:)   => null() ! col moisture tendency due to vertical movement at topmost layer (m3/m3/s)
-    real(r8), pointer :: excess_ice         (:)   => null() ! NGEE-Arctic: tracking excess ground ice
     ! Area fractions
     real(r8), pointer :: frac_sno           (:)   => null() ! fraction of ground covered by snow (0 to 1)
     real(r8), pointer :: frac_sno_eff       (:)   => null() ! fraction of ground covered by snow (0 to 1)
@@ -1385,8 +1385,17 @@ contains
     allocate(this%h2osoi_liq         (begc:endc,-nlevsno+1:nlevgrnd)) ; this%h2osoi_liq         (:,:) = spval
     allocate(this%h2osoi_ice         (begc:endc,-nlevsno+1:nlevgrnd)) ; this%h2osoi_ice         (:,:) = spval
     allocate(this%h2osoi_vol         (begc:endc, 1:nlevgrnd))         ; this%h2osoi_vol         (:,:) = spval
+<<<<<<< HEAD
     allocate(this%h2osfc             (begc:endc))                     ; this%h2osfc             (:)   = spval   
     allocate(this%h2ocan             (begc:endc))                     ; this%h2ocan             (:)   = spval 
+||||||| parent of 88480f7699 (Update excess_ice from single column value to depth varying)
+    allocate(this%h2osfc             (begc:endc))                     ; this%h2osfc             (:)   = spval
+    allocate(this%h2ocan             (begc:endc))                     ; this%h2ocan             (:)   = spval
+=======
+    allocate(this%excess_ice         (begc:endc, 1:nlevgrnd))         ; this%excess_ice         (:,:) = spval
+    allocate(this%h2osfc             (begc:endc))                     ; this%h2osfc             (:)   = spval
+    allocate(this%h2ocan             (begc:endc))                     ; this%h2ocan             (:)   = spval
+>>>>>>> 88480f7699 (Update excess_ice from single column value to depth varying)
     allocate(this%wslake_col         (begc:endc))                     ; this%wslake_col         (:)   = spval
     allocate(this%total_plant_stored_h2o(begc:endc))                  ; this%total_plant_stored_h2o(:)= spval  
     allocate(this%h2osoi_liqvol      (begc:endc,-nlevsno+1:nlevgrnd)) ; this%h2osoi_liqvol      (:,:) = spval
@@ -1418,7 +1427,6 @@ contains
     if (use_fan) then
        allocate(this%h2osoi_tend_tsl_col(begc:endc))                  ; this%h2osoi_tend_tsl_col(:)   = spval
     end if
-    allocate(this%excess_ice         (begc:endc))                     ; this%excess_ice         (:)   = spval
     allocate(this%snw_rds_top        (begc:endc))                     ; this%snw_rds_top        (:)   = spval
     allocate(this%do_capsnow         (begc:endc))
     allocate(this%frac_sno           (begc:endc))                     ; this%frac_sno           (:)   = spval
@@ -1474,9 +1482,14 @@ contains
          ptr_col=this%h2osoi_ice, l2g_scale_type='veg')
 
     this%h2osoi_ice(begc:endc,:) = spval
-        call hist_addfld2d (fname='SOILICE_ICE',  units='kg/m2', type2d='levgrnd', &
-        avgflag='A', long_name='soil ice (ice landunits only)', &
-        ptr_col=this%h2osoi_ice, l2g_scale_type='ice')
+    call hist_addfld2d (fname='SOILICE_ICE',  units='kg/m2', type2d='levgrnd', &
+         avgflag='A', long_name='soil ice (ice landunits only)', &
+         ptr_col=this%h2osoi_ice, l2g_scale_type='ice')
+
+    this%excess_ice(begc:endc, :) = spval
+    call hist_addfld2d (fname='EXCESS_ICE', units = '1', type2d='levgrnd', &
+         avgflag='A', long_name='Excess ground ice (0 to 1)', &
+         ptr_col=this%excess_ice, l2g_scale_type='veg') ! <- RPF: should this be natveg?
 
     this%h2osfc(begc:endc) = spval
      call hist_addfld1d (fname='H2OSFC',  units='mm',  &
@@ -1566,11 +1579,6 @@ contains
          default='inactive')
     end if
 
-    this%excess_ice(begc:endc) = spval
-    call hist_addfld1d (fname='EXCESS_ICE', units = '1', &
-         avgflag='A', long_name='Excess ground ice (0 to 1)', &
-         ptr_col=this%excess_ice, l2g_scale_type='veg') ! <- RPF: should this be natveg?
-
     this%frac_sno(begc:endc) = spval
     call hist_addfld1d (fname='FSNO',  units='1',  &
          avgflag='A', long_name='fraction of ground covered by snow', &
@@ -1642,7 +1650,6 @@ contains
        this%frac_h2osfc_act(c)        = 0._r8
        this%h2orof(c)                 = 0._r8
        this%frac_h2orof(c)            = 0._r8
-       this%excess_ice(c)             = 0.5_r8
 
        if (lun_pp%urbpoi(l)) then
           ! From Bonan 1996 (LSM technical note)
@@ -1800,6 +1807,17 @@ contains
              this%h2osoi_ice(c,j) = 0._r8
              this%h2osoi_liq(c,j) = col_pp%dz(c,j)*denh2o*this%h2osoi_vol(c,j)
           endif
+          ! RPF - to do: a) apply to only polygonal ground
+          ! b) pull in ALT information to get starting point right.
+          ! for now, assuming no excess ice in top meter, 0.5 for 1-4 m,
+          ! 0.2 below 4 m. Also: need to check signs!
+          if (col_pp%z(c,j) > -1._r8) then
+            this%excess_ice(c,j) = 0._r8
+          else if (col_pp%z(c,j) > -4._r8 .and. col_pp%z(c,j) < -1._r8) then
+            this%excess_ice(c,j) = 0.5_r8
+          else
+            this%excess_ice(c,j) = 0.2_r8
+          end if
        end do
 
        this%h2osoi_liq_old(c,:) = this%h2osoi_liq(c,:)
@@ -1856,6 +1874,11 @@ contains
          dim1name='column', dim2name='levtot', switchdim=.true., &
          long_name='ice lens', units='kg/m2', &
          interpinic_flag='interp', readvar=readvar, data=this%h2osoi_ice)
+
+    call restartvar(ncid=ncid, flag=flag, varname='EXCESS_ICE', xtype=ncd_double, &
+         dim1name='column', dim2name='levgrnd', switchdim=.true., &
+         long_name='excess ground ice (0 to 1)', units='1', &
+         interpinic_flag='interp', readvar=readvar, data=this%excess_ice)
 
     call restartvar(ncid=ncid, flag=flag, varname='SOILP', xtype=ncd_double,  &
          dim1name='column', dim2name='levgrnd', switchdim=.true., &
@@ -1919,11 +1942,6 @@ contains
     if (flag=='read' .and. .not. readvar) then
          this%snow_persistence(:) = 0.0_r8
     end if
-
-    call restartvar(ncid=ncid, flag=flag, varname='EXCESS_ICE', xtype=ncd_double, &
-         dim1name='column', &
-         long_name='excess ground ice (0 to 1)', units='1', &
-         interpinic_flag='interp', readvar=readvar, data=this%excess_ice)
 
     call restartvar(ncid=ncid, flag=flag, varname='frac_sno', xtype=ncd_double,  &
          dim1name='column', &

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -1515,9 +1515,9 @@ contains
             long_name='microtopographic depression depth (m)', ptr_col=this%iwp_ddep)
       call hist_addfld1d (fname="EXCLUDED_VOL", units='m', avgflag='A', &
             long_name='volume of soil above lowest point on IWP surface, normalized by polygon area', &
-            ptr_col=this%iwp_ddep)
+            ptr_col=this%iwp_exclvol)
       call hist_addfld1d (fname="MICROREL", units='m', avgflag='A', &
-            long_name='microtopographic relief (m)', ptr_col=this%iwp_ddep)
+            long_name='microtopographic relief (m)', ptr_col=this%iwp_microrel)
     endif
     !/polygonal tundra
 
@@ -1680,6 +1680,7 @@ contains
        this%frac_h2osfc_act(c)        = 0._r8
        this%h2orof(c)                 = 0._r8
        this%frac_h2orof(c)            = 0._r8
+       this%iwp_subsidence(c)         = 0._r8
 
        if (lun_pp%urbpoi(l)) then
           ! From Bonan 1996 (LSM technical note)

--- a/components/elm/src/data_types/ColumnType.F90
+++ b/components/elm/src/data_types/ColumnType.F90
@@ -49,17 +49,19 @@ module ColumnType
      logical , pointer :: active       (:) => null() ! true=>do computations on this column
 
      ! topography
-     real(r8), pointer :: glc_topo     (:) => null() ! surface elevation (m)
-     real(r8), pointer :: micro_sigma  (:) => null() ! microtopography pdf sigma (m)
-     real(r8), pointer :: n_melt       (:) => null() ! SCA shape parameter
-     real(r8), pointer :: topo_slope   (:) => null() ! gridcell topographic slope
-     real(r8), pointer :: topo_std     (:) => null() ! gridcell elevation standard deviation
-     real(r8), pointer :: hslp_p10     (:,:) => null() ! hillslope slope percentiles (unitless)
-     integer, pointer  :: nlevbed      (:) => null() ! number of layers to bedrock
-     real(r8), pointer :: zibed        (:) => null() ! bedrock depth in model (interface level at nlevbed)
-     real(r8), pointer :: iwp_microrel (:) => null() ! ice wedge polygon microtopographic relief (m)
-     real(r8), pointer :: iwp_exclvol  (:) => null() ! ice wedge polygon excluded volume (m)
-     real(r8), pointer :: iwp_ddep     (:) => null() ! ice wedge polygon depression depth (m)
+     real(r8), pointer :: glc_topo      (:) => null() ! surface elevation (m)
+     real(r8), pointer :: micro_sigma   (:) => null() ! microtopography pdf sigma (m)
+     real(r8), pointer :: n_melt        (:) => null() ! SCA shape parameter
+     real(r8), pointer :: topo_slope    (:) => null() ! gridcell topographic slope
+     real(r8), pointer :: topo_std      (:) => null() ! gridcell elevation standard deviation
+     real(r8), pointer :: hslp_p10      (:,:) => null() ! hillslope slope percentiles (unitless)
+     integer, pointer  :: nlevbed       (:) => null() ! number of layers to bedrock
+     real(r8), pointer :: zibed         (:) => null() ! bedrock depth in model (interface level at nlevbed)
+     real(r8), pointer :: iwp_microrel  (:) => null() ! ice wedge polygon microtopographic relief (m)
+     real(r8), pointer :: iwp_exclvol   (:) => null() ! ice wedge polygon excluded volume (m)
+     real(r8), pointer :: iwp_ddep      (:) => null() ! ice wedge polygon depression depth (m)
+     real(r8), pointer :: iwp_subsidence(:) => null() ! ice wedge polygon ground subsidence (m)
+     real(r8), pointer :: meangradz     (:) => null() ! mean topographic gradient at the column level
 
      ! vertical levels
      integer , pointer :: snl          (:)   => null() ! number of snow layers
@@ -134,12 +136,18 @@ contains
     allocate(this%hslp_p10    (begc:endc,nlevslp))             ; this%hslp_p10    (:,:) = spval
     allocate(this%nlevbed     (begc:endc))                     ; this%nlevbed     (:)   = ispval
     allocate(this%zibed       (begc:endc))                     ; this%zibed       (:)   = spval
+    ! polygonal tundra/ice wedge polygons:
+    allocate(this%iwp_microrel  (begc:endc))                   ; this%iwp_microrel  (:) = spval
+    allocate(this%iwp_exclvol   (begc:endc))                   ; this%iwp_exclvol   (:) = spval
+    allocate(this%iwp_ddep      (begc:endc))                   ; this%iwp_ddep      (:) = spval
+    allocate(this%iwp_subsidence(begc:endc))                   ; this%iwp_subsidence(:) = spval
+    allocate(this%meangradz     (begc:endc))                   ; this%meangradz     (:) = spval
 
     allocate(this%hydrologically_active(begc:endc))            ; this%hydrologically_active(:) = .false.
 
     ! Assume that columns are not fates columns until fates initialization begins
     allocate(this%is_fates(begc:endc)); this%is_fates(:) = .false.
-    
+
   end subroutine col_pp_init
 
   !------------------------------------------------------------------------
@@ -176,9 +184,14 @@ contains
     deallocate(this%hslp_p10   )
     deallocate(this%nlevbed    )
     deallocate(this%zibed      )
+    deallocate(this%iwp_microrel)
+    deallocate(this%iwp_exclvol )
+    deallocate(this%iwp_ddep    )
+    deallocate(this%iwp_subsidence)
+    deallocate(this%meangradz     )
     deallocate(this%hydrologically_active)
     deallocate(this%is_fates)
-    
+
   end subroutine col_pp_clean
 
 end module ColumnType

--- a/components/elm/src/data_types/ColumnType.F90
+++ b/components/elm/src/data_types/ColumnType.F90
@@ -175,11 +175,6 @@ contains
     deallocate(this%hslp_p10   )
     deallocate(this%nlevbed    )
     deallocate(this%zibed      )
-    ! RPF note: moving these to col_ws, but col_ws never seems to be deallocated?
-    !deallocate(this%iwp_microrel)
-    !deallocate(this%iwp_exclvol )
-    !deallocate(this%iwp_ddep    )
-    !deallocate(this%iwp_subsidence)
     deallocate(this%meangradz     )
     deallocate(this%hydrologically_active)
     deallocate(this%is_fates)

--- a/components/elm/src/data_types/ColumnType.F90
+++ b/components/elm/src/data_types/ColumnType.F90
@@ -57,6 +57,9 @@ module ColumnType
      real(r8), pointer :: hslp_p10     (:,:) => null() ! hillslope slope percentiles (unitless)
      integer, pointer  :: nlevbed      (:) => null() ! number of layers to bedrock
      real(r8), pointer :: zibed        (:) => null() ! bedrock depth in model (interface level at nlevbed)
+	 real(r8), pointer :: iwp_microrel (:) => null() ! ice wedge polygon microtopographic relief (m)
+	 real(r8), pointer :: iwp_exclvol  (:) => null() ! ice wedge polygon excluded volume (m)
+	 real(r8), pointer :: iwp_ddep     (:) => null() ! ice wedge polygon depression depth (m)
 
      ! vertical levels
      integer , pointer :: snl          (:)   => null() ! number of snow layers

--- a/components/elm/src/data_types/ColumnType.F90
+++ b/components/elm/src/data_types/ColumnType.F90
@@ -57,9 +57,9 @@ module ColumnType
      real(r8), pointer :: hslp_p10     (:,:) => null() ! hillslope slope percentiles (unitless)
      integer, pointer  :: nlevbed      (:) => null() ! number of layers to bedrock
      real(r8), pointer :: zibed        (:) => null() ! bedrock depth in model (interface level at nlevbed)
-	 real(r8), pointer :: iwp_microrel (:) => null() ! ice wedge polygon microtopographic relief (m)
-	 real(r8), pointer :: iwp_exclvol  (:) => null() ! ice wedge polygon excluded volume (m)
-	 real(r8), pointer :: iwp_ddep     (:) => null() ! ice wedge polygon depression depth (m)
+     real(r8), pointer :: iwp_microrel (:) => null() ! ice wedge polygon microtopographic relief (m)
+     real(r8), pointer :: iwp_exclvol  (:) => null() ! ice wedge polygon excluded volume (m)
+     real(r8), pointer :: iwp_ddep     (:) => null() ! ice wedge polygon depression depth (m)
 
      ! vertical levels
      integer , pointer :: snl          (:)   => null() ! number of snow layers

--- a/components/elm/src/data_types/ColumnType.F90
+++ b/components/elm/src/data_types/ColumnType.F90
@@ -57,10 +57,6 @@ module ColumnType
      real(r8), pointer :: hslp_p10      (:,:) => null() ! hillslope slope percentiles (unitless)
      integer, pointer  :: nlevbed       (:) => null() ! number of layers to bedrock
      real(r8), pointer :: zibed         (:) => null() ! bedrock depth in model (interface level at nlevbed)
-     real(r8), pointer :: iwp_microrel  (:) => null() ! ice wedge polygon microtopographic relief (m)
-     real(r8), pointer :: iwp_exclvol   (:) => null() ! ice wedge polygon excluded volume (m)
-     real(r8), pointer :: iwp_ddep      (:) => null() ! ice wedge polygon depression depth (m)
-     real(r8), pointer :: iwp_subsidence(:) => null() ! ice wedge polygon ground subsidence (m)
      real(r8), pointer :: meangradz     (:) => null() ! mean topographic gradient at the column level
 
      ! vertical levels
@@ -136,12 +132,7 @@ contains
     allocate(this%hslp_p10    (begc:endc,nlevslp))             ; this%hslp_p10    (:,:) = spval
     allocate(this%nlevbed     (begc:endc))                     ; this%nlevbed     (:)   = ispval
     allocate(this%zibed       (begc:endc))                     ; this%zibed       (:)   = spval
-    ! polygonal tundra/ice wedge polygons:
-    allocate(this%iwp_microrel  (begc:endc))                   ; this%iwp_microrel  (:) = spval
-    allocate(this%iwp_exclvol   (begc:endc))                   ; this%iwp_exclvol   (:) = spval
-    allocate(this%iwp_ddep      (begc:endc))                   ; this%iwp_ddep      (:) = spval
-    allocate(this%iwp_subsidence(begc:endc))                   ; this%iwp_subsidence(:) = spval
-    allocate(this%meangradz     (begc:endc))                   ; this%meangradz     (:) = spval
+    allocate(this%meangradz   (begc:endc))                     ; this%meangradz   (:)   = spval
 
     allocate(this%hydrologically_active(begc:endc))            ; this%hydrologically_active(:) = .false.
 
@@ -184,10 +175,11 @@ contains
     deallocate(this%hslp_p10   )
     deallocate(this%nlevbed    )
     deallocate(this%zibed      )
-    deallocate(this%iwp_microrel)
-    deallocate(this%iwp_exclvol )
-    deallocate(this%iwp_ddep    )
-    deallocate(this%iwp_subsidence)
+    ! RPF note: moving these to col_ws, but col_ws never seems to be deallocated?
+    !deallocate(this%iwp_microrel)
+    !deallocate(this%iwp_exclvol )
+    !deallocate(this%iwp_ddep    )
+    !deallocate(this%iwp_subsidence)
     deallocate(this%meangradz     )
     deallocate(this%hydrologically_active)
     deallocate(this%is_fates)

--- a/components/elm/src/data_types/LandunitType.F90
+++ b/components/elm/src/data_types/LandunitType.F90
@@ -47,6 +47,8 @@ module LandunitType
      logical , pointer :: urbpoi       (:) => null() ! true=>urban point
      logical , pointer :: glcmecpoi    (:) => null() ! true=>glacier_mec point
      logical , pointer :: active       (:) => null() ! true=>do computations on this landunit
+	 logical , pointer :: ispolygon    (:) => null() ! true=>is polygonal tundra
+	 integer , pointer :: polygontype  (:) => null() ! ice wedge polygon initial condition (LCP, FCP, or HCP)
 
      ! urban properties
      real(r8), pointer :: canyon_hwr   (:) => null() ! urban landunit canyon height to width ratio (-)
@@ -93,6 +95,8 @@ contains
     allocate(this%lakpoi       (begl:endl)); this%lakpoi    (:) = .false.
     allocate(this%urbpoi       (begl:endl)); this%urbpoi    (:) = .false.
     allocate(this%glcmecpoi    (begl:endl)); this%glcmecpoi (:) = .false.
+	allocate(this%ispolygon    (begl:endl)); this%ispolygon (:) = .false.
+	allocate(this%polygontype  (begl:endl)); this%polygontype(:) = ispval
 
     ! The following is initialized in routine setActive in module reweightMod
     allocate(this%active       (begl:endl))
@@ -129,6 +133,8 @@ contains
     deallocate(this%lakpoi       )
     deallocate(this%urbpoi       )
     deallocate(this%glcmecpoi    )
+	deallocate(this%ispolygon    )
+	deallocate(this%polygontype  )
     deallocate(this%active       )
     deallocate(this%canyon_hwr   )
     deallocate(this%wtroad_perv  )

--- a/components/elm/src/data_types/LandunitType.F90
+++ b/components/elm/src/data_types/LandunitType.F90
@@ -47,8 +47,8 @@ module LandunitType
      logical , pointer :: urbpoi       (:) => null() ! true=>urban point
      logical , pointer :: glcmecpoi    (:) => null() ! true=>glacier_mec point
      logical , pointer :: active       (:) => null() ! true=>do computations on this landunit
-	 logical , pointer :: ispolygon    (:) => null() ! true=>is polygonal tundra
-	 integer , pointer :: polygontype  (:) => null() ! ice wedge polygon initial condition (LCP, FCP, or HCP)
+     logical , pointer :: ispolygon    (:) => null() ! true=>is polygonal tundra
+     integer , pointer :: polygontype  (:) => null() ! ice wedge polygon initial condition (LCP, FCP, or HCP)
 
      ! urban properties
      real(r8), pointer :: canyon_hwr   (:) => null() ! urban landunit canyon height to width ratio (-)
@@ -95,8 +95,8 @@ contains
     allocate(this%lakpoi       (begl:endl)); this%lakpoi    (:) = .false.
     allocate(this%urbpoi       (begl:endl)); this%urbpoi    (:) = .false.
     allocate(this%glcmecpoi    (begl:endl)); this%glcmecpoi (:) = .false.
-	allocate(this%ispolygon    (begl:endl)); this%ispolygon (:) = .false.
-	allocate(this%polygontype  (begl:endl)); this%polygontype(:) = ispval
+    allocate(this%ispolygon    (begl:endl)); this%ispolygon (:) = .false.
+    allocate(this%polygontype  (begl:endl)); this%polygontype(:) = ispval
 
     ! The following is initialized in routine setActive in module reweightMod
     allocate(this%active       (begl:endl))
@@ -133,8 +133,8 @@ contains
     deallocate(this%lakpoi       )
     deallocate(this%urbpoi       )
     deallocate(this%glcmecpoi    )
-	deallocate(this%ispolygon    )
-	deallocate(this%polygontype  )
+    deallocate(this%ispolygon    )
+    deallocate(this%polygontype  )
     deallocate(this%active       )
     deallocate(this%canyon_hwr   )
     deallocate(this%wtroad_perv  )

--- a/components/elm/src/main/controlMod.F90
+++ b/components/elm/src/main/controlMod.F90
@@ -325,16 +325,19 @@ contains
 
     namelist /elm_mosart/ &
          lnd_rof_coupling_nstep
-		 
+
     namelist /elm_inparm/ &
-         snow_shape, snicar_atm_type, use_dust_snow_internal_mixing 
-    
-    namelist /elm_inparm/ & 
+         snow_shape, snicar_atm_type, use_dust_snow_internal_mixing
+
+    namelist /elm_inparm/ &
          use_modified_infil
 
     namelist /elm_inparm/ &
          use_fan, fan_mode, fan_to_bgc_veg, nh4_ads_coef
 
+   ! NGEE Arctic options
+   namelist /elm_inparm/ &
+         use_polygonal_tundra
     ! ----------------------------------------------------------------------
     ! Default values
     ! ----------------------------------------------------------------------
@@ -995,6 +998,8 @@ contains
     ! use modified infiltration scheme in surface water storage
     call mpi_bcast (use_modified_infil, 1, MPI_LOGICAL, 0, mpicom, ier)
 
+    !NGEE Arctic options
+    call mpi_bcast (use_polygonal_tundra, 1, MPI_LOGICAL, 0, mpicom, ier)
   end subroutine control_spmd
 
   !------------------------------------------------------------------------
@@ -1275,6 +1280,8 @@ contains
        write(iulog,*) ' fan_to_bgc_veg = ', fan_to_bgc_veg
     end if
 
+    ! NGEE Arctic options
+    if (use_polygonal_tundra) write(iulog, *) '    use_polygonal_tundra    =', use_polygonal_tundra
   end subroutine control_print
 
 end module controlMod

--- a/components/elm/src/main/controlMod.F90
+++ b/components/elm/src/main/controlMod.F90
@@ -337,7 +337,7 @@ contains
 
    ! NGEE Arctic options
    namelist /elm_inparm/ &
-         use_polygonal_tundra
+         use_polygonal_tundra, use_arctic_init
     ! ----------------------------------------------------------------------
     ! Default values
     ! ----------------------------------------------------------------------
@@ -1000,6 +1000,8 @@ contains
 
     !NGEE Arctic options
     call mpi_bcast (use_polygonal_tundra, 1, MPI_LOGICAL, 0, mpicom, ier)
+    call mpi_bcast (use_arctic_init, 1, MPI_LOGICAL, 0, mpicom, ier)
+
   end subroutine control_spmd
 
   !------------------------------------------------------------------------
@@ -1282,6 +1284,8 @@ contains
 
     ! NGEE Arctic options
     if (use_polygonal_tundra) write(iulog, *) '    use_polygonal_tundra    =', use_polygonal_tundra
+    if (use_arctic_init) write(iulog, *)      '    use_arctic_init    ='     , use_arctic_init
+
   end subroutine control_print
 
 end module controlMod

--- a/components/elm/src/main/elm_initializeMod.F90
+++ b/components/elm/src/main/elm_initializeMod.F90
@@ -280,12 +280,7 @@ contains
        allocate (wt_glc_mec  (1,1,1))
        allocate (topo_glc_mec(1,1,1))
     endif
-    if (use_polygonal_tundra) then
-      allocate (wt_polygon (begg:endg,1:max_topounits, max_polygon))
-    else
-      allocate (wt_polygon (begg:endg,1:max_topounits, 1)) ! RF-not sure this is needed
-    endif
-
+    allocate (wt_polygon (begg:endg,1:max_topounits, max_polygon))
     allocate (wt_tunit  (begg:endg,1:max_topounits  ))
     allocate (elv_tunit (begg:endg,1:max_topounits  ))
     allocate (slp_tunit (begg:endg,1:max_topounits  ))

--- a/components/elm/src/main/elm_initializeMod.F90
+++ b/components/elm/src/main/elm_initializeMod.F90
@@ -283,7 +283,7 @@ contains
     if (use_polygonal_tundra) then
       allocate (wt_polygon (begg:endg,1:max_topounits, max_polygon))
     else
-      allocate (wt_polygon (1,1,1)) ! RF-not sure this is needed
+      allocate (wt_polygon (begg:endg,1:max_topounits, 1)) ! RF-not sure this is needed
     endif
 
     allocate (wt_tunit  (begg:endg,1:max_topounits  ))

--- a/components/elm/src/main/elm_initializeMod.F90
+++ b/components/elm/src/main/elm_initializeMod.F90
@@ -63,7 +63,7 @@ contains
     use elm_varpar                , only: update_pft_array_bounds
     use elm_varpar                , only: surfpft_lb, surfpft_ub
     use elm_varcon                , only: elm_varcon_init
-    use landunit_varcon           , only: landunit_varcon_init, max_lunit, istice_mec, max_polygon
+    use landunit_varcon           , only: landunit_varcon_init, max_lunit, istice_mec, max_polygon, max_non_poly_lunit
     use column_varcon             , only: col_itype_to_icemec_class
     use elm_varctl                , only: fsurdat, fatmlndfrc, flndtopo, fglcmask, noland, version
     use pftvarcon                 , only: pftconrd
@@ -267,7 +267,11 @@ contains
 
     ! Allocate surface grid dynamic memory (just gridcell bounds dependent)
 
-    allocate (wt_lunit     (begg:endg,1:max_topounits, max_lunit           )) 
+    if (use_polygonal_tundra) then
+      allocate (wt_lunit     (begg:endg,1:max_topounits, max_lunit           ))
+    else
+      allocate (wt_lunit     (begg:endg,1:max_topounits, max_non_poly_lunit  ))
+    end if
     allocate (urban_valid  (begg:endg,1:max_topounits                      ))
     !allocate (wt_nat_patch (begg:endg,1:max_topounits, surfpft_lb:surfpft_ub ))
     !allocate (wt_cft       (begg:endg,1:max_topounits, cft_lb:cft_ub       ))

--- a/components/elm/src/main/elm_initializeMod.F90
+++ b/components/elm/src/main/elm_initializeMod.F90
@@ -14,7 +14,7 @@ module elm_initializeMod
   use elm_varctl       , only : use_lch4, use_cn, use_voc, use_c13, use_c14
   use elm_varctl       , only : use_fates, use_betr, use_fates_sp, use_fan, use_fates_luh
   use elm_varsur       , only : wt_lunit, urban_valid, wt_nat_patch, wt_cft, wt_glc_mec, topo_glc_mec,firrig,f_surf,f_grd
-  use elm_varsur       , only : fert_cft, fert_p_cft
+  use elm_varsur       , only : fert_cft, fert_p_cft, wt_polygon
   use elm_varsur       , only : wt_tunit, elv_tunit, slp_tunit,asp_tunit,num_tunit_per_grd
   use perf_mod         , only : t_startf, t_stopf
   !use readParamsMod    , only : readParameters
@@ -63,7 +63,7 @@ contains
     use elm_varpar                , only: update_pft_array_bounds
     use elm_varpar                , only: surfpft_lb, surfpft_ub
     use elm_varcon                , only: elm_varcon_init
-    use landunit_varcon           , only: landunit_varcon_init, max_lunit, istice_mec
+    use landunit_varcon           , only: landunit_varcon_init, max_lunit, istice_mec, max_polygon
     use column_varcon             , only: col_itype_to_icemec_class
     use elm_varctl                , only: fsurdat, fatmlndfrc, flndtopo, fglcmask, noland, version
     use pftvarcon                 , only: pftconrd
@@ -87,7 +87,7 @@ contains
     use filterMod                 , only: allocFilters
     use reweightMod               , only: reweight_wrapup
     use topounit_varcon           , only: max_topounits, has_topounit, topounit_varcon_init
-    use elm_varctl                , only: use_top_solar_rad
+    use elm_varctl                , only: use_top_solar_rad, use_polygonal_tundra
     !
     ! !LOCAL VARIABLES:
     integer           :: ier                     ! error status
@@ -280,8 +280,13 @@ contains
        allocate (wt_glc_mec  (1,1,1))
        allocate (topo_glc_mec(1,1,1))
     endif
-    
-    allocate (wt_tunit  (begg:endg,1:max_topounits  )) 
+    if (use_polygonal_tundra) then
+      allocate (wt_polygon (begg:endg,1:max_topounits, max_polygon))
+    else
+      allocate (wt_polygon (1,1,1)) ! RF-not sure this is needed
+    endif
+
+    allocate (wt_tunit  (begg:endg,1:max_topounits  ))
     allocate (elv_tunit (begg:endg,1:max_topounits  ))
     allocate (slp_tunit (begg:endg,1:max_topounits  ))
     allocate (asp_tunit (begg:endg,1:max_topounits  ))
@@ -430,6 +435,7 @@ contains
     !deallocate (wt_lunit, wt_cft, wt_glc_mec)
     deallocate (wt_cft, wt_glc_mec)    !wt_lunit not deallocated because it is being used in CanopyHydrologyMod.F90
     deallocate (wt_tunit, elv_tunit, slp_tunit, asp_tunit,num_tunit_per_grd)
+    deallocate (wt_polygon) ! RF - might be used elsewhere, not sure if we want to deallocate here.
     call t_stopf('elm_init1')
 
     ! initialize glc_topo

--- a/components/elm/src/main/elm_varctl.F90
+++ b/components/elm/src/main/elm_varctl.F90
@@ -394,7 +394,11 @@ module elm_varctl
   logical, public :: fan_nh3_to_atm      = .false.
   logical, public :: fan_to_bgc_crop     = .false.
   logical, public :: fan_to_bgc_veg      = .false.
- 
+
+  !----------------------------------------------------------
+  ! NGEE Arctic parameterizations
+  !----------------------------------------------------------
+  logical, public :: use_polygonal_tundra = .false.
 
   !----------------------------------------------------------
   ! VSFM switches

--- a/components/elm/src/main/elm_varctl.F90
+++ b/components/elm/src/main/elm_varctl.F90
@@ -399,6 +399,7 @@ module elm_varctl
   ! NGEE Arctic parameterizations
   !----------------------------------------------------------
   logical, public :: use_polygonal_tundra = .false.
+  logical, public :: use_arctic_init     = .false.
 
   !----------------------------------------------------------
   ! VSFM switches

--- a/components/elm/src/main/elm_varsur.F90
+++ b/components/elm/src/main/elm_varsur.F90
@@ -22,7 +22,13 @@ module elm_varsur
   ! for natural veg landunit, weight of each pft on the landunit (adds to 1.0 on the
   ! landunit for all all grid cells, even! those without any natural pft)
   ! (second dimension goes natpft_lb:natpft_ub)
-  real(r8), pointer :: wt_nat_patch(:,:,:)   
+  real(r8), pointer :: wt_nat_patch(:,:,:)
+
+  ! for polygonal tundra special case of natural veg landunit, weight of polygon type
+  ! with respect to the natural vegetation landunit (NOT the grid cell). these do
+  ! not need to sum to 1 to preserve possibility of polygonal tundra and non-polygonal
+  ! ground on the same grid cell, on the vegetated landunit.
+  real(r8), pointer :: wt_polygon(:,:,:) ! dims: clump, topounit, polygon type
 
   ! for crop landunit, weight of each cft on the landunit (adds to 1.0 on the
   ! landunit for all all grid cells, even  those without any crop)

--- a/components/elm/src/main/initGridCellsMod.F90
+++ b/components/elm/src/main/initGridCellsMod.F90
@@ -13,7 +13,7 @@ module initGridCellsMod
   use spmdMod        , only : masterproc,iam
   use abortutils     , only : endrun
   use elm_varctl     , only : iulog
-  use elm_varctl     , only : use_fates, use_fates_sp
+  use elm_varctl     , only : use_fates, use_fates_sp, use_polygonal_tundra
   use elm_varcon     , only : namep, namec, namel, nameg
   use decompMod      , only : bounds_type, ldecomp
   use GridcellType   , only : grc_pp
@@ -22,7 +22,7 @@ module initGridCellsMod
   use ColumnType     , only : col_pp                
   use VegetationType , only : veg_pp                
   use initSubgridMod , only : elm_ptrs_compdown, elm_ptrs_check
-  use initSubgridMod , only : add_topounit, add_landunit, add_column, add_patch
+  use initSubgridMod , only : add_topounit, add_landunit, add_polygon_landunit, add_column, add_patch
   !
   ! !PUBLIC TYPES:
   implicit none
@@ -317,7 +317,7 @@ contains
     logical , intent(in)    :: setdata           ! set info or just compute
     !
     ! !LOCAL VARIABLES:
-    integer  :: m,tgi                                ! index
+    integer  :: m,tgi,z                          ! index
     integer  :: npfts                            ! number of pfts in landunit
     integer  :: pitype                           ! patch itype
     real(r8) :: wtlunit2topounit                 ! landunit weight on topounit
@@ -342,6 +342,7 @@ contains
     ! by using said mapping table
     
     if (npfts > 0) then
+      ! do standard veg landunit first
        call add_landunit(li=li, ti=ti, ltype=ltype, wttopounit=wtlunit2topounit)
        
        ! Assume one column on the landunit
@@ -354,6 +355,27 @@ contains
           end if
           call add_patch(pi=pi, ci=ci, ptype=m, wtcol=p_wt)
        end do
+
+       ! add polygonal landunits and columns if feature turned on
+       ! continue to assume one column per landunit.
+       if (use_polygonal_tundra) then
+         ! loop over polygon types:
+         do z = 1,3
+           call add_polygon_landunit(li=li, ti=ti, ltype=ltype, wttopounit=wtlunit2topounit, polytype = z)
+           call add_column(ci=ci, li=li, ctype=1, wtlunit=1.0_r8)
+           ! add patch:
+           do m = natpft_lb,natpft_ub
+             if(use_fates .and. .not.use_fates_sp) then
+               p_wt = 1.0_r8/real(natpft_size,r8)
+             else
+               p_wt = wt_nat_patch(gi,topo_ind,m)
+             end if
+             call add_patch(pi=pi, ci=ci, ptype=m, wtcol=p_wt)
+             write(iulog,*) "polygon column counter:", z, pi, ci, li, ti
+           end do 
+         end do
+       end if 
+
     end if
 
   end subroutine set_landunit_veg_compete
@@ -492,7 +514,7 @@ contains
     !
     ! !LOCAL VARIABLES:
     integer  :: my_ltype                         ! landunit type for crops
-    integer  :: m,tgi                                ! index
+    integer  :: m,tgi,z                                ! index
     integer  :: npfts                            ! number of pfts in landunit
     real(r8) :: wtlunit2topounit                 ! landunit weight in topounit
     !------------------------------------------------------------------------
@@ -517,7 +539,7 @@ contains
        end if
 
        call add_landunit(li=li, ti=ti, ltype=my_ltype, wttopounit=wtlunit2topounit)
-       
+
        ! Set column and pft properties for this landunit 
        ! (each column has its own pft)
 

--- a/components/elm/src/main/initGridCellsMod.F90
+++ b/components/elm/src/main/initGridCellsMod.F90
@@ -342,14 +342,6 @@ contains
     ! c) natural vegetation, flat centered polygons
     ! d) natural vegetation, low centered polygons
 
-    !if (use_polygonal_tundra) then
-    !  orig_wtlunit2topounit = wtlunit2topounit
-    !  ! adjust wtlunit2topounit to subtract fraction that is polygonal
-    !  wtlunit2topounit = wtlunit2topounit * (1._r8 - sum(wt_polygon(gi, topo_ind, :))) ! sum over polygon types
-    !  ! DEBUG:
-    !  write(iulog,*) "DEBUG / new, original, polygon weights are:",wtlunit2topounit,orig_wtlunit2topounit,wt_polygon(gi,topo_ind,:)
-    !endif
-
     ! For FATES: the total number of patches may not match what is in the surface
     ! file, and therefor the weighting can't be used. The weightings in
     ! wt_nat_patch may be meaningful (like with fixed biogeography), but they
@@ -390,8 +382,7 @@ contains
                p_wt = wt_nat_patch(gi,topo_ind,m)
              end if
              call add_patch(pi=pi, ci=ci, ptype=m, wtcol=p_wt)
-             write(iulog,*) "polygon column counter:", z, pi, ci, li, ti
-           end do 
+           end do
          end do
        end if 
 

--- a/components/elm/src/main/initGridCellsMod.F90
+++ b/components/elm/src/main/initGridCellsMod.F90
@@ -305,7 +305,7 @@ contains
     use elm_varsur, only : wt_lunit, wt_nat_patch, wt_polygon
     use subgridMod, only : subgrid_get_topounitinfo
     use elm_varpar, only : numpft, maxpatch_pft, numcft, natpft_lb, natpft_ub, natpft_size
-    use landunit_varcon, only: max_polygon
+    use landunit_varcon, only: istlowcenpoly, istflatcenpoly, isthighcenpoly, max_non_poly_lunit
     !
     ! !ARGUMENTS:    
     integer , intent(in)    :: ltype             ! landunit type
@@ -324,8 +324,6 @@ contains
     real(r8) :: wtlunit2topounit                 ! landunit weight on topounit
     real(r8) :: p_wt                             ! patch weight (0-1)
     real(r8) :: wtpoly2lndunit                   ! weight of polygon type wrt nat. veg. landunit
-    real(r8) :: orig_wtlunit2topounit            ! keep original total wtlunit2topounit when
-                                                 ! adjusting to reallocate to polygon types.
     !------------------------------------------------------------------------
 
     ! Set decomposition properties
@@ -344,11 +342,13 @@ contains
     ! c) natural vegetation, flat centered polygons
     ! d) natural vegetation, low centered polygons
 
-    if (use_polygonal_tundra) then
-      orig_wtlunit2topounit = wtlunit2topounit
-      ! adjust wtlunit2topounit to subtract fraction that is polygonal
-      wtlunit2topounit = wtlunit2topounit * (1._r8 - sum(wt_polygon(gi, topo_ind, :))) ! sum over polygon types
-    endif
+    !if (use_polygonal_tundra) then
+    !  orig_wtlunit2topounit = wtlunit2topounit
+    !  ! adjust wtlunit2topounit to subtract fraction that is polygonal
+    !  wtlunit2topounit = wtlunit2topounit * (1._r8 - sum(wt_polygon(gi, topo_ind, :))) ! sum over polygon types
+    !  ! DEBUG:
+    !  write(iulog,*) "DEBUG / new, original, polygon weights are:",wtlunit2topounit,orig_wtlunit2topounit,wt_polygon(gi,topo_ind,:)
+    !endif
 
     ! For FATES: the total number of patches may not match what is in the surface
     ! file, and therefor the weighting can't be used. The weightings in
@@ -377,10 +377,10 @@ contains
        ! continue to assume one column per landunit.
        if (use_polygonal_tundra) then
          ! loop over polygon types:
-         do z = 1,max_polygon
-            ! get new weight for wttopounit:
-            wtpoly2lndunit = orig_wtlunit2topounit * wt_polygon(gi, topo_ind, z)
-           call add_polygon_landunit(li=li, ti=ti, ltype=ltype, wttopounit=wtpoly2lndunit, polytype = z)
+         do z = istlowcenpoly,isthighcenpoly
+           ! get new weight for wttopounit:
+           wtpoly2lndunit = wt_lunit(gi, topo_ind, z) 
+           call add_polygon_landunit(li=li, ti=ti, ltype=ltype, wttopounit=wtpoly2lndunit, polytype = z - max_non_poly_lunit)
            call add_column(ci=ci, li=li, ctype=1, wtlunit=1.0_r8)
            ! add patch:
            do m = natpft_lb,natpft_ub

--- a/components/elm/src/main/initGridCellsMod.F90
+++ b/components/elm/src/main/initGridCellsMod.F90
@@ -302,9 +302,10 @@ contains
     ! Initialize vegetated landunit with competition
     !
     ! !USES
-    use elm_varsur, only : wt_lunit, wt_nat_patch
+    use elm_varsur, only : wt_lunit, wt_nat_patch, wt_polygon
     use subgridMod, only : subgrid_get_topounitinfo
     use elm_varpar, only : numpft, maxpatch_pft, numcft, natpft_lb, natpft_ub, natpft_size
+    use landunit_varcon, only: max_polygon
     !
     ! !ARGUMENTS:    
     integer , intent(in)    :: ltype             ! landunit type
@@ -322,6 +323,9 @@ contains
     integer  :: pitype                           ! patch itype
     real(r8) :: wtlunit2topounit                 ! landunit weight on topounit
     real(r8) :: p_wt                             ! patch weight (0-1)
+    real(r8) :: wtpoly2lndunit                   ! weight of polygon type wrt nat. veg. landunit
+    real(r8) :: orig_wtlunit2topounit            ! keep original total wtlunit2topounit when
+                                                 ! adjusting to reallocate to polygon types.
     !------------------------------------------------------------------------
 
     ! Set decomposition properties
@@ -332,6 +336,19 @@ contains
     ! Later, this information will come from new surface datasat.
     call subgrid_get_topounitinfo(ti, gi,tgi=topo_ind, nveg=npfts)
     wtlunit2topounit = wt_lunit(gi,topo_ind, ltype)
+
+    ! for polygonal tundra, we need to adjust the weight of the landunit as
+    ! this wtlunit2topounit now corresponds to 4 landunits:
+    ! a) natural vegetation, no polygonal tundra
+    ! b) natural vegetation, high centered polygons
+    ! c) natural vegetation, flat centered polygons
+    ! d) natural vegetation, low centered polygons
+
+    if (use_polygonal_tundra) then
+      orig_wtlunit2topounit = wtlunit2topounit
+      ! adjust wtlunit2topounit to subtract fraction that is polygonal
+      wtlunit2topounit = wtlunit2topounit * (1._r8 - sum(wt_polygon(gi, topo_ind, :))) ! sum over polygon types
+    endif
 
     ! For FATES: the total number of patches may not match what is in the surface
     ! file, and therefor the weighting can't be used. The weightings in
@@ -360,8 +377,10 @@ contains
        ! continue to assume one column per landunit.
        if (use_polygonal_tundra) then
          ! loop over polygon types:
-         do z = 1,3
-           call add_polygon_landunit(li=li, ti=ti, ltype=ltype, wttopounit=wtlunit2topounit, polytype = z)
+         do z = 1,max_polygon
+            ! get new weight for wttopounit:
+            wtpoly2lndunit = orig_wtlunit2topounit * wt_polygon(gi, topo_ind, z)
+           call add_polygon_landunit(li=li, ti=ti, ltype=ltype, wttopounit=wtpoly2lndunit, polytype = z)
            call add_column(ci=ci, li=li, ctype=1, wtlunit=1.0_r8)
            ! add patch:
            do m = natpft_lb,natpft_ub

--- a/components/elm/src/main/initSubgridMod.F90
+++ b/components/elm/src/main/initSubgridMod.F90
@@ -498,7 +498,7 @@ contains
    ! This verison of add_landunit is specific to polygonal tundra.
    !
    ! !USES:
-   use landunit_varcon , only : istsoil, istcrop, istice_mec, istdlak, isturb_MIN, isturb_MAX
+   use landunit_varcon , only : istsoil
    !
    ! !ARGUMENTS:
    integer  , intent(inout) :: li         ! input value is index of last landunit added; output value is index of this newly-added landunit

--- a/components/elm/src/main/initSubgridMod.F90
+++ b/components/elm/src/main/initSubgridMod.F90
@@ -29,6 +29,7 @@ module initSubgridMod
   public :: elm_ptrs_check    ! checks and writes out a summary of subgrid data
   public :: add_topounit      ! add an entry in the topounit-level arrays
   public :: add_landunit      ! add an entry in the landunit-level arrays
+  public :: add_polygon_landunit ! adds an entry in the landunit-level arrays for the special type of polygonal ground.
   public :: add_column        ! add an entry in the column-level arrays
   public :: add_patch         ! add an entry in the patch-level arrays
   !
@@ -475,6 +476,51 @@ contains
     end if
 
   end subroutine add_landunit
+
+!-----------------------------------------------------------------------
+  subroutine add_polygon_landunit(li, ti, ltype, wttopounit, polytype)
+   !
+   ! !DESCRIPTION:
+   ! Add an entry in the landunit-level arrays. li gives the index of the last landunit
+   ! added; the new landunit is added at li+1, and the li argument is incremented
+   ! accordingly.
+   !
+   ! This verison of add_landunit is specific to polygonal tundra.
+   !
+   ! !USES:
+   use landunit_varcon , only : istsoil, istcrop, istice_mec, istdlak, isturb_MIN, isturb_MAX
+   !
+   ! !ARGUMENTS:
+   integer  , intent(inout) :: li         ! input value is index of last landunit added; output value is index of this newly-added landunit
+   integer  , intent(in)    :: ti         ! topounit index on which this landunit should be placed
+   integer  , intent(in)    :: ltype      ! landunit type
+   real(r8) , intent(in)    :: wttopounit ! weight of the landunit relative to the topounit
+   integer  , intent(in)    :: polytype   ! defines the type of ice wedge polygon this landunit corresponds to
+   !
+   ! !LOCAL VARIABLES:
+
+   character(len=*), parameter :: subname = 'add_polygon_landunit'
+   !-----------------------------------------------------------------------
+
+   li = li + 1
+
+   lun_pp%topounit(li) = ti
+   lun_pp%gridcell(li) = top_pp%gridcell(ti)
+
+   lun_pp%wttopounit(li) = wttopounit
+   lun_pp%itype(li) = ltype
+
+   if (ltype == istsoil) then
+      lun_pp%ifspecial(li) = .false.
+      lun_pp%ispolygon(li) = .true.
+      lun_pp%polygontype(li) = polytype
+   else
+      write (iulog, *) "ERROR: attempting to assign polygonal tundra landunit to special or crop landunit type"
+      call endrun(msg=errMsg(__FILE__, __LINE__))
+   end if
+
+ end subroutine add_polygon_landunit
+
 
   !-----------------------------------------------------------------------
   subroutine add_column(ci, li, ctype, wtlunit)

--- a/components/elm/src/main/initSubgridMod.F90
+++ b/components/elm/src/main/initSubgridMod.F90
@@ -10,7 +10,7 @@ module initSubgridMod
   use shr_log_mod    , only : errMsg => shr_log_errMsg
   use spmdMod        , only : masterproc
   use abortutils     , only : endrun
-  use elm_varctl     , only : iulog
+  use elm_varctl     , only : iulog, use_polygonal_tundra
   use elm_varcon     , only : namep, namec, namel, namet
   use decompMod      , only : bounds_type
   use GridcellType   , only : grc_pp                
@@ -62,6 +62,7 @@ contains
     ! !USES
     use elm_varcon, only : ispval
     use topounit_varcon, only : max_topounits
+    use landunit_varcon, only : max_non_poly_lunit, istsoil
     !
     ! !ARGUMENTS
     implicit none
@@ -148,6 +149,9 @@ contains
     grc_pp%landunit_indices(:,bounds%begg:bounds%endg) = ispval
     do l = bounds%begl,bounds%endl
        ltype = lun_pp%itype(l)
+       if (use_polygonal_tundra .and. ltype == istsoil .and. lun_pp%ispolygon(l)) then
+         ltype = lun_pp%polygontype(l) + max_non_poly_lunit
+       endif
        curg = lun_pp%gridcell(l)
        if (curg < bounds%begg .or. curg > bounds%endg) then
           write(iulog,*) 'elm_ptrs_compdown ERROR: gridcell landunit_indices ', l,curg,bounds%begg,bounds%endg
@@ -171,6 +175,9 @@ contains
     top_pp%landunit_indices(:,bounds%begt:bounds%endt) = ispval
     do l = bounds%begl,bounds%endl
        ltype = lun_pp%itype(l)
+       if (use_polygonal_tundra .and. ltype == istsoil .and. lun_pp%ispolygon(l)) then
+         ltype = lun_pp%polygontype(l) + max_non_poly_lunit
+       endif
        curt = lun_pp%topounit(l)
        if (curt < bounds%begt .or. curg > bounds%endt) then
           write(iulog,*) 'elm_ptrs_compdown ERROR: topounit landunit_indices ', l,curt,bounds%begt,bounds%endt
@@ -196,7 +203,7 @@ contains
     !
     ! !USES
     use elm_varcon, only : ispval
-    use landunit_varcon, only : max_lunit
+    use landunit_varcon, only : max_lunit, istsoil
     use topounit_varcon, only : max_topounits
     !
     ! !ARGUMENTS
@@ -350,7 +357,10 @@ contains
 
           ! skip l == ispval, which implies that this landunit type doesn't exist on this grid cell
           if (l /= ispval) then
-             if (lun_pp%itype(l) /= ltype) error = .true.
+             if (lun_pp%itype(l) /= ltype) then
+               if (lun_pp%ispolygon(l) .and. lun_pp%itype(l) /= istsoil) error = .true.
+               if (.not.lun_pp%ispolygon(l)) error = .true.
+             endif
              if (lun_pp%topounit(l) /= t) error = .true.
              if (lun_pp%gridcell(l) /= g) error = .true.
              if (error) then
@@ -514,6 +524,9 @@ contains
       lun_pp%ifspecial(li) = .false.
       lun_pp%ispolygon(li) = .true.
       lun_pp%polygontype(li) = polytype
+      lun_pp%urbpoi(li) = .false.
+      lun_pp%lakpoi(li) = .false.
+      lun_pp%glcmecpoi(li) = .false.
    else
       write (iulog, *) "ERROR: attempting to assign polygonal tundra landunit to special or crop landunit type"
       call endrun(msg=errMsg(__FILE__, __LINE__))

--- a/components/elm/src/main/initVerticalMod.F90
+++ b/components/elm/src/main/initVerticalMod.F90
@@ -22,8 +22,9 @@ module initVerticalMod
   use column_varcon  , only : icol_roof, icol_sunwall, icol_shadewall, icol_road_perv, icol_road_imperv
   use landunit_varcon, only : istdlak, istice_mec
   use fileutils      , only : getfil
-  use LandunitType   , only : lun_pp                
-  use ColumnType     , only : col_pp                
+  use LandunitType   , only : lun_pp
+  use ColumnType     , only : col_pp
+  use ColumnDataType , only : col_ws
   use SnowHydrologyMod, only : InitSnowLayers
   use ncdio_pio
   use topounit_varcon  , only : max_topounits
@@ -584,6 +585,7 @@ contains
             g = col_pp%gridcell(c)
             col_pp%meangradz(c) = gradz(g)
          end do
+         deallocate(gradz)
       end if
 
       allocate(std(bounds%begg:bounds%endg))

--- a/components/elm/src/main/initVerticalMod.F90
+++ b/components/elm/src/main/initVerticalMod.F90
@@ -17,8 +17,8 @@ module initVerticalMod
   use elm_varpar     , only : nlevsoi, nlevsoifl, nlevurb, nlevslp 
   use elm_varctl     , only : fsurdat, iulog, use_var_soil_thick
   use elm_varctl     , only : use_vancouver, use_mexicocity, use_vertsoilc, use_extralakelayers, use_extrasnowlayers
-  use elm_varctl     , only : use_erosion
-  use elm_varcon     , only : zlak, dzlak, zsoi, dzsoi, zisoi, dzsoi_decomp, spval, grlnd 
+  use elm_varctl     , only : use_erosion, use_polygonal_tundra
+  use elm_varcon     , only : zlak, dzlak, zsoi, dzsoi, zisoi, dzsoi_decomp, spval, grlnd
   use column_varcon  , only : icol_roof, icol_sunwall, icol_shadewall, icol_road_perv, icol_road_imperv
   use landunit_varcon, only : istdlak, istice_mec
   use fileutils      , only : getfil
@@ -55,8 +55,9 @@ contains
     logical               :: readvar 
     integer               :: dimid             ! dimension id
     character(len=256)    :: locfn             ! local filename
-    real(r8) ,pointer     :: std (:)           ! read in - topo_std 
-    real(r8) ,pointer     :: tslope (:)        ! read in - topo_slope 
+    real(r8) ,pointer     :: std (:)           ! read in - topo_std
+    real(r8) ,pointer     :: tslope (:)        ! read in - topo_slope
+    real(r8) ,pointer     :: gradz(:)          ! read in - gradz (polygonal tundra only)
     real(r8) ,pointer     :: hslp_p10 (:,:,:)    ! read in - hillslope slope percentiles
     real(r8) ,pointer     :: dtb (:,:)           ! read in - DTB
     real(r8)              :: beddep            ! temporary
@@ -571,6 +572,19 @@ contains
          col_pp%topo_slope(c) = max(tslope(g), 0.2_r8)
       end do
       deallocate(tslope)
+
+      if (use_polygonal_tundra) then
+         allocate(gradz(bounds%begg:bounds%endg))
+         call ncd_io(ncid=ncid, varname='GRADZ', flag='read', data=gradz, dim1name=grlnd, readvar=readvar)
+         if (.not. readvar) then
+            call shr_sys_abort(' ERROR: polygonal tundra turned on, but GRADZ not on surfdata file'//&
+            errMsg(__FILE__, __LINE__))
+         end if
+         do c = begc,endc
+            g = col_pp%gridcell(c)
+            col_pp%meangradz(c) = gradz(g)
+         end do
+      end if
 
       allocate(std(bounds%begg:bounds%endg))
       call ncd_io(ncid=ncid, varname='STD_ELEV', flag='read', data=std, dim1name=grlnd, readvar=readvar)

--- a/components/elm/src/main/landunit_varcon.F90
+++ b/components/elm/src/main/landunit_varcon.F90
@@ -35,7 +35,12 @@ module landunit_varcon
 
   integer, parameter, public                   :: landunit_name_length = 40  ! max length of landunit names
   character(len=landunit_name_length), public  :: landunit_names(max_lunit)  ! name of each landunit type
-
+  
+  ! land unit polygonal ground types
+  integer, parameter, public :: ilowcenpoly     = 1     ! low-centered polygons
+  integer, parameter, public :: iflatcenpoly    = 2	    ! flat-centered polygons
+  integer, parameter, public :: ihighcenpoly    = 3	    ! high-centered polygons
+  
   ! parameters that depend on the above constants
 
   integer, parameter, public :: numurbl = isturb_MAX - isturb_MIN + 1   ! number of urban landunits
@@ -48,6 +53,7 @@ module landunit_varcon
   !
   ! !PRIVATE MEMBER FUNCTIONS:
   private :: set_landunit_names   ! set the landunit_names vector
+  private :: set_polygon_names    ! set the polygon_names vector
 !-----------------------------------------------------------------------
 
 contains
@@ -97,6 +103,30 @@ contains
     end if
 
   end function landunit_is_special
+
+  subroutine set_polygon_names
+    !
+    ! !DESCRIPTION:
+    ! Set the polygon_names vector
+    !
+    ! !USES:
+    use shr_sys_mod, only : shr_sys_abort
+    !
+    character(len=*), parameter :: not_set = 'NOT_SET'
+    character(len=*), parameter :: subname = 'set_polygon_names'
+    !-----------------------------------------------------------------------
+    
+    polygon_names(:) = not_set
+
+    polygon_names(ilowcenpoly) = 'low_centered_polygons'
+    polygon_names(iflatcenpoly) = 'flat_centered_polygons'
+    polygon_names(ihighcenpoly) = 'high_centered_polygons'
+
+    if (any(polygon_names == not_set)) then
+       call shr_sys_abort(trim(subname)//': Not all polygon names set')
+    end if
+ 
+  end subroutine set_polygon_names
 
   !-----------------------------------------------------------------------
   subroutine set_landunit_names

--- a/components/elm/src/main/landunit_varcon.F90
+++ b/components/elm/src/main/landunit_varcon.F90
@@ -29,9 +29,13 @@ module landunit_varcon
   integer, parameter, public :: isturb_hd  = 8  !urban hd     landunit type
   integer, parameter, public :: isturb_md  = 9  !urban md     landunit type
   integer, parameter, public :: isturb_MAX = 9  !maximum urban type index
+  integer, parameter, public :: istlowcenpoly  = 10 ! low centered polygon landunit type
+  integer, parameter, public :: istflatcenpoly = 11 ! flat cenetered polygon landunit type
+  integer, parameter, public :: isthighcenpoly = 12 ! high centered polygon landunit type
 
-  integer, parameter, public :: max_lunit  = 9  !maximum value that lun_pp%itype can have
+  integer, parameter, public :: max_lunit  = 12  !maximum value that lun_pp%itype can have
                                         !(i.e., largest value in the above list)
+  integer, parameter, public :: max_non_poly_lunit = 9 ! maximum non-polygonal tundra land unit
 
   integer, parameter, public                   :: landunit_name_length = 40  ! max length of landunit names
   character(len=landunit_name_length), public  :: landunit_names(max_lunit)  ! name of each landunit type
@@ -160,6 +164,9 @@ contains
     landunit_names(isturb_tbd) = 'urban_tbd'
     landunit_names(isturb_hd) = 'urban_hd'
     landunit_names(isturb_md) = 'urban_md'
+    landunit_names(istlowcenpoly) = 'low_centered_polygon'
+    landunit_names(istflatcenpoly) = 'flat_centered_polygon'
+    landunit_names(isthighcenpoly) = 'high_centered_polygon'
 
     if (any(landunit_names == not_set)) then
        call shr_sys_abort(trim(subname)//': Not all landunit names set')

--- a/components/elm/src/main/landunit_varcon.F90
+++ b/components/elm/src/main/landunit_varcon.F90
@@ -41,6 +41,14 @@ module landunit_varcon
   integer, parameter, public :: iflatcenpoly    = 2	    ! flat-centered polygons
   integer, parameter, public :: ihighcenpoly    = 3	    ! high-centered polygons
   
+  integer, parameter, public :: max_poly  = 3  !maximum value that lun_pp%polygontype can have
+                                        !(i.e., largest value in the above list)
+
+  integer, parameter, public                   :: polygon_name_length = 40  ! max length of landunit names
+  character(len=polygon_name_length), public   :: polygon_names(max_poly)  ! name of each landunit type
+  
+  
+  
   ! parameters that depend on the above constants
 
   integer, parameter, public :: numurbl = isturb_MAX - isturb_MIN + 1   ! number of urban landunits

--- a/components/elm/src/main/landunit_varcon.F90
+++ b/components/elm/src/main/landunit_varcon.F90
@@ -6,6 +6,7 @@ module landunit_varcon
   !
   ! !USES:
 #include "shr_assert.h"
+    use elm_varctl, only : use_polygonal_tundra
   !
   !
   ! !PUBLIC TYPES:
@@ -38,8 +39,8 @@ module landunit_varcon
   integer, parameter, public :: max_non_poly_lunit = 9 ! maximum non-polygonal tundra land unit
 
   integer, parameter, public                   :: landunit_name_length = 40  ! max length of landunit names
-  character(len=landunit_name_length), public  :: landunit_names(max_lunit)  ! name of each landunit type
-  
+  character(len=landunit_name_length), allocatable, public  :: landunit_names(:)  ! name of each landunit type
+
   ! land unit polygonal ground types
   integer, parameter, public :: ilowcenpoly     = 1     ! low-centered polygons
   integer, parameter, public :: iflatcenpoly    = 2     ! flat-centered polygons
@@ -65,6 +66,7 @@ module landunit_varcon
   ! !PRIVATE MEMBER FUNCTIONS:
   private :: set_landunit_names   ! set the landunit_names vector
   private :: set_polygon_names    ! set the polygon_names vector
+
 !-----------------------------------------------------------------------
 
 contains
@@ -148,11 +150,18 @@ contains
     !
     ! !USES:
     use shr_sys_mod, only : shr_sys_abort
+
     !
     character(len=*), parameter :: not_set = 'NOT_SET'
     character(len=*), parameter :: subname = 'set_landunit_names'
     !-----------------------------------------------------------------------
-    
+
+    if (use_polygonal_tundra) then
+      allocate(landunit_names(max_lunit))
+    else
+      allocate(landunit_names(max_non_poly_lunit))
+    end if
+
     landunit_names(:) = not_set
 
     landunit_names(istsoil) = 'vegetated_or_bare_soil'
@@ -164,9 +173,11 @@ contains
     landunit_names(isturb_tbd) = 'urban_tbd'
     landunit_names(isturb_hd) = 'urban_hd'
     landunit_names(isturb_md) = 'urban_md'
-    landunit_names(istlowcenpoly) = 'low_centered_polygon'
-    landunit_names(istflatcenpoly) = 'flat_centered_polygon'
-    landunit_names(isthighcenpoly) = 'high_centered_polygon'
+    if (use_polygonal_tundra) then
+      landunit_names(istlowcenpoly) = 'low_centered_polygon'
+      landunit_names(istflatcenpoly) = 'flat_centered_polygon'
+      landunit_names(isthighcenpoly) = 'high_centered_polygon'
+    end if
 
     if (any(landunit_names == not_set)) then
        call shr_sys_abort(trim(subname)//': Not all landunit names set')

--- a/components/elm/src/main/landunit_varcon.F90
+++ b/components/elm/src/main/landunit_varcon.F90
@@ -40,15 +40,14 @@ module landunit_varcon
   integer, parameter, public :: ilowcenpoly     = 1     ! low-centered polygons
   integer, parameter, public :: iflatcenpoly    = 2     ! flat-centered polygons
   integer, parameter, public :: ihighcenpoly    = 3     ! high-centered polygons
-  
-  integer, parameter, public :: max_poly  = 3  !maximum value that lun_pp%polygontype can have
-                                        !(i.e., largest value in the above list)
+
+  integer, parameter, public :: max_polygon = 3  !maximum value that lun_pp%polygontype can have
+                                                 !(i.e., largest value in the above list)
 
   integer, parameter, public                   :: polygon_name_length = 40  ! max length of landunit names
-  character(len=polygon_name_length), public   :: polygon_names(max_poly)  ! name of each landunit type
-  
-  
-  
+  character(len=polygon_name_length), public   :: polygon_names(max_polygon)! name of each landunit type
+
+
   ! parameters that depend on the above constants
 
   integer, parameter, public :: numurbl = isturb_MAX - isturb_MIN + 1   ! number of urban landunits

--- a/components/elm/src/main/landunit_varcon.F90
+++ b/components/elm/src/main/landunit_varcon.F90
@@ -38,8 +38,8 @@ module landunit_varcon
   
   ! land unit polygonal ground types
   integer, parameter, public :: ilowcenpoly     = 1     ! low-centered polygons
-  integer, parameter, public :: iflatcenpoly    = 2	    ! flat-centered polygons
-  integer, parameter, public :: ihighcenpoly    = 3	    ! high-centered polygons
+  integer, parameter, public :: iflatcenpoly    = 2     ! flat-centered polygons
+  integer, parameter, public :: ihighcenpoly    = 3     ! high-centered polygons
   
   integer, parameter, public :: max_poly  = 3  !maximum value that lun_pp%polygontype can have
                                         !(i.e., largest value in the above list)
@@ -82,6 +82,7 @@ contains
     !-----------------------------------------------------------------------
     
     call set_landunit_names()
+    call set_polygon_names()
 
   end subroutine landunit_varcon_init
   

--- a/components/elm/src/main/restFileMod.F90
+++ b/components/elm/src/main/restFileMod.F90
@@ -1019,7 +1019,8 @@ contains
     ! Add global metadata defining landunit types
     !
     ! !USES:
-    use landunit_varcon, only : max_lunit, landunit_names, landunit_name_length
+    use landunit_varcon, only : max_lunit, max_non_poly_lunit, landunit_names, landunit_name_length
+    use elm_varctl,      only : use_polygonal_tundra
     !
     ! !ARGUMENTS:
     type(file_desc_t), intent(inout) :: ncid ! local file id
@@ -1032,10 +1033,17 @@ contains
     character(len=*), parameter :: subname = 'restFile_add_ilun_metadata'
     !-----------------------------------------------------------------------
     
-    do ltype = 1, max_lunit
-       attname = att_prefix // landunit_names(ltype)
-       call ncd_putatt(ncid, ncd_global, attname, ltype)
-    end do
+    if (use_polygonal_tundra) then
+      do ltype = 1, max_lunit
+        attname = att_prefix // landunit_names(ltype)
+        call ncd_putatt(ncid, ncd_global, attname, ltype)
+      end do
+    else
+      do ltype = 1, max_non_poly_lunit
+        attname = att_prefix // landunit_names(ltype)
+        call ncd_putatt(ncid, ncd_global, attname, ltype)
+      end do
+    end if
 
   end subroutine restFile_add_ilun_metadata
 

--- a/components/elm/src/main/subgridMod.F90
+++ b/components/elm/src/main/subgridMod.F90
@@ -40,7 +40,7 @@ contains
     !
     ! !USES
     use elm_varpar  , only : natpft_size, cft_size, maxpatch_urb, maxpatch_glcmec
-    use elm_varctl  , only : create_crop_landunit
+    use elm_varctl  , only : create_crop_landunit, use_polygonal_tundra
     use elm_varsur  , only : wt_lunit, urban_valid, wt_glc_mec
     use landunit_varcon  , only : istsoil, istcrop, istice, istice_mec, istdlak, istwet, &
                              isturb_tbd, isturb_hd, isturb_md
@@ -159,6 +159,13 @@ contains
 
        if (present(nveg)) nveg = nveg + npfts_per_lunit
 
+       ! polygonal tundra
+       if (use_polygonal_tundra) then
+         ilunits = ilunits + 3
+         icols = icols + 3
+         ipfts = ipfts + 3 * npfts_per_lunit
+         ! if (present(nveg)) nveg = nveg + 3 * npfts_per_lunit
+       endif
        ! -------------------------------------------------------------------------
        ! Set urban landunits
        ! -------------------------------------------------------------------------
@@ -334,7 +341,7 @@ contains
     !
     ! !USES
     use elm_varpar  , only : natpft_size, cft_size, maxpatch_urb, maxpatch_glcmec
-    use elm_varctl  , only : create_crop_landunit
+    use elm_varctl  , only : create_crop_landunit, use_polygonal_tundra
     use elm_varsur  , only : wt_lunit, urban_valid, wt_glc_mec
     use landunit_varcon  , only : istsoil, istcrop, istice, istice_mec, istdlak, istwet, &
                              isturb_tbd, isturb_hd, isturb_md
@@ -422,6 +429,17 @@ contains
     icohorts = fates_maxElementsPerSite
 
     if (present(nveg)) nveg = nveg + npfts_per_lunit
+
+    ! -----------------------------------------------------------------------
+    ! polygonal tundra
+
+    ! polygonal tundra
+    if (use_polygonal_tundra) then
+      ilunits = ilunits + 3
+      icols = icols + 3
+      ipfts = ipfts + 3 * npfts_per_lunit
+      ! if (present(nveg)) nveg = nveg + 3 * npfts_per_lunit
+    endif
 
     ! -------------------------------------------------------------------------
     ! Set urban landunits

--- a/components/elm/src/main/surfrdMod.F90
+++ b/components/elm/src/main/surfrdMod.F90
@@ -35,7 +35,7 @@ module surfrdMod
   !
   ! !PUBLIC MEMBER FUNCTIONS:
   public :: surfrd_get_globmask  ! Reads global land mask (needed for setting domain decomp)
-  public :: surfrd_get_grid      ! Read grid/ladnfrac data into domain (after domain decomp)
+  public :: surfrd_get_grid      ! Read grid/landfrac data into domain (after domain decomp)
   public :: surfrd_get_topo      ! Read grid topography into domain (after domain decomp)
   public :: surfrd_get_data      ! Read surface dataset and determine subgrid weights
   public :: surfrd_get_grid_conn ! Reads grid connectivity information from domain file

--- a/components/elm/src/main/surfrdMod.F90
+++ b/components/elm/src/main/surfrdMod.F90
@@ -1192,6 +1192,8 @@ contains
          dim1name=grlnd, readvar=readvar)
       if (.not. readvar) call endrun( msg=' ERROR: use_polygonal_tundra = .true., but PCT_LCP NOT on surfdata file'//errMsg(__FILE__, __LINE__))
       wt_polygon(begg:endg,1:max_topounits,ilowcenpoly) = arrayl(begg:endg,1:max_topounits)
+    else
+      wt_polygon(begg:endg,1:max_topounits,1) = 0._r8
     endif
 
     ! add two other types
@@ -1266,9 +1268,7 @@ contains
     end if
     wt_lunit(begg:endg,:,istsoil) = wt_lunit(begg:endg,:,istsoil) / 100._r8
     wt_lunit(begg:endg,:,istcrop) = wt_lunit(begg:endg,:,istcrop) / 100._r8
-    wt_polygon(begg:endg,:,ihighcenpoly) = wt_polygon(begg:endg,:,ihighcenpoly) / 100._r8
-    wt_polygon(begg:endg,:,iflatcenpoly) = wt_polygon(begg:endg,:,iflatcenpoly) / 100._r8
-    wt_polygon(begg:endg,:,ilowcenpoly) = wt_polygon(begg:endg,:,ilowcenpoly) / 100._r8
+    wt_polygon(begg:endg,:,:) = wt_polygon(begg:endg,:,:) / 100._r8
     wt_nat_patch(begg:endg,:,:)   = wt_nat_patch(begg:endg,:,:) / 100._r8
     !call check_sums_equal_1_3d(wt_nat_patch, begg, 'wt_nat_patch', subname,ntpu)
     call check_sums_equal_1_3d(wt_nat_patch, begg, 'wt_nat_patch', subname)

--- a/components/elm/src/main/surfrdMod.F90
+++ b/components/elm/src/main/surfrdMod.F90
@@ -732,7 +732,6 @@ contains
        call endrun(msg=errMsg(__FILE__, __LINE__))
     end if
     call domain_clean(surfdata_domain)
-
     ! Obtain special landunit info
 
     call surfrd_special(begg, endg, ncid, ldomain%ns,ldomain%num_tunits_per_grd)
@@ -1136,7 +1135,8 @@ contains
     use elm_varpar      , only : surfpft_lb, surfpft_ub, surfpft_size, cft_lb, cft_ub, cft_size
     use elm_varpar      , only : crop_prog
     use elm_varsur      , only : wt_lunit, wt_nat_patch, wt_cft, fert_cft, fert_p_cft, wt_polygon
-    use landunit_varcon , only : istsoil, istcrop, ilowcenpoly, iflatcenpoly, ihighcenpoly
+    use landunit_varcon , only : istsoil, istcrop
+    use landunit_varcon , only : istlowcenpoly, ilowcenpoly, istflatcenpoly, iflatcenpoly, isthighcenpoly, ihighcenpoly
     use pftvarcon       , only : nc3crop, nc3irrig, npcropmin
     use pftvarcon       , only : ncorn, ncornirrig, nsoybean, nsoybeanirrig
     use pftvarcon       , only : nscereal, nscerealirrig, nwcereal, nwcerealirrig
@@ -1193,7 +1193,8 @@ contains
       if (.not. readvar) call endrun( msg=' ERROR: use_polygonal_tundra = .true., but PCT_LCP NOT on surfdata file'//errMsg(__FILE__, __LINE__))
       wt_polygon(begg:endg,1:max_topounits,ilowcenpoly) = arrayl(begg:endg,1:max_topounits)
     else
-      wt_polygon(begg:endg,1:max_topounits,1) = 0._r8
+      wt_polygon(begg:endg,1:max_topounits,ilowcenpoly:ihighcenpoly) = 0._r8
+      wt_lunit(begg:endg,1:max_topounits,istlowcenpoly:isthighcenpoly) = 0._r8
     endif
 
     ! add two other types

--- a/components/elm/src/main/surfrdMod.F90
+++ b/components/elm/src/main/surfrdMod.F90
@@ -1131,12 +1131,12 @@ contains
     ! Determine weight arrays for non-dynamic landuse mode
     !
     ! !USES:
-    use elm_varctl      , only : create_crop_landunit, use_fates
+    use elm_varctl      , only : create_crop_landunit, use_fates, use_polygonal_tundra
     use elm_varctl      , only : irrigate
     use elm_varpar      , only : surfpft_lb, surfpft_ub, surfpft_size, cft_lb, cft_ub, cft_size
     use elm_varpar      , only : crop_prog
-    use elm_varsur      , only : wt_lunit, wt_nat_patch, wt_cft, fert_cft, fert_p_cft
-    use landunit_varcon , only : istsoil, istcrop
+    use elm_varsur      , only : wt_lunit, wt_nat_patch, wt_cft, fert_cft, fert_p_cft, wt_polygon
+    use landunit_varcon , only : istsoil, istcrop, ilowcenpoly, iflatcenpoly, ihighcenpoly
     use pftvarcon       , only : nc3crop, nc3irrig, npcropmin
     use pftvarcon       , only : ncorn, ncornirrig, nsoybean, nsoybeanirrig
     use pftvarcon       , only : nscereal, nscerealirrig, nwcereal, nwcerealirrig
@@ -1175,7 +1175,26 @@ contains
     call ncd_io(ncid=ncid, varname='PCT_NATVEG', flag='read', data=arrayl, &
          dim1name=grlnd, readvar=readvar)
     if (.not. readvar) call endrun( msg=' ERROR: PCT_NATVEG NOT on surfdata file'//errMsg(__FILE__, __LINE__))
-    wt_lunit(begg:endg,1:max_topounits,istsoil) = arrayl(begg:endg,1:max_topounits) 
+    wt_lunit(begg:endg,1:max_topounits,istsoil) = arrayl(begg:endg,1:max_topounits)
+
+    if (use_polygonal_tundra) then
+      call ncd_io(ncid=ncid, varname='PCT_HCP', flag='read', data=arrayl, &
+         dim1name=grlnd, readvar=readvar)
+      if (.not. readvar) call endrun( msg=' ERROR: use_polygonal_tundra = .true., but PCT_HCP NOT on surfdata file'//errMsg(__FILE__, __LINE__))
+      wt_polygon(begg:endg,1:max_topounits,ihighcenpoly) = arrayl(begg:endg,1:max_topounits)
+
+      call ncd_io(ncid=ncid, varname='PCT_FCP', flag='read', data=arrayl, &
+         dim1name=grlnd, readvar=readvar)
+      if (.not. readvar) call endrun( msg=' ERROR: use_polygonal_tundra = .true., but PCT_FCP NOT on surfdata file'//errMsg(__FILE__, __LINE__))
+      wt_polygon(begg:endg,1:max_topounits,iflatcenpoly) = arrayl(begg:endg,1:max_topounits)
+
+      call ncd_io(ncid=ncid, varname='PCT_LCP', flag='read', data=arrayl, &
+         dim1name=grlnd, readvar=readvar)
+      if (.not. readvar) call endrun( msg=' ERROR: use_polygonal_tundra = .true., but PCT_LCP NOT on surfdata file'//errMsg(__FILE__, __LINE__))
+      wt_polygon(begg:endg,1:max_topounits,ilowcenpoly) = arrayl(begg:endg,1:max_topounits)
+    endif
+
+    ! add two other types
 
     call ncd_io(ncid=ncid, varname='PCT_CROP', flag='read', data=arrayl, &
          dim1name=grlnd, readvar=readvar)
@@ -1247,6 +1266,9 @@ contains
     end if
     wt_lunit(begg:endg,:,istsoil) = wt_lunit(begg:endg,:,istsoil) / 100._r8
     wt_lunit(begg:endg,:,istcrop) = wt_lunit(begg:endg,:,istcrop) / 100._r8
+    wt_polygon(begg:endg,:,ihighcenpoly) = wt_polygon(begg:endg,:,ihighcenpoly) / 100._r8
+    wt_polygon(begg:endg,:,iflatcenpoly) = wt_polygon(begg:endg,:,iflatcenpoly) / 100._r8
+    wt_polygon(begg:endg,:,ilowcenpoly) = wt_polygon(begg:endg,:,ilowcenpoly) / 100._r8
     wt_nat_patch(begg:endg,:,:)   = wt_nat_patch(begg:endg,:,:) / 100._r8
     !call check_sums_equal_1_3d(wt_nat_patch, begg, 'wt_nat_patch', subname,ntpu)
     call check_sums_equal_1_3d(wt_nat_patch, begg, 'wt_nat_patch', subname)

--- a/components/elm/src/main/surfrdMod.F90
+++ b/components/elm/src/main/surfrdMod.F90
@@ -1222,7 +1222,7 @@ contains
     else if ( (.not. cft_dim_exists) .and. (.not. create_crop_landunit) )then
 
        ! Format where crop is part of the natural veg. landunit
-       if ( masterproc ) write(iulog,*) "WARNING: The PFT format is an unsupported format that will be removed in th future!"
+       if ( masterproc ) write(iulog,*) "WARNING: The PFT format is an unsupported format that will be removed in the future!"
        call surfrd_pftformat( begg, endg, ncid )
 
     else if ( cft_dim_exists .and. .not. create_crop_landunit )then
@@ -1348,6 +1348,26 @@ contains
        call collapse_crop_var(fert_cft(begg:endg,:,:), begg, endg)
        call collapse_crop_var(fert_p_cft(begg:endg,:,:), begg, endg)
     end if
+
+    if (use_polygonal_tundra) then
+      ! adjust wt_lunit(:,:,istsoil) for polygonal fraction:
+      do nl = begg,endg
+        do t = 1,max_topounits
+          wt_lunit(nl,t,istlowcenpoly) = wt_lunit(nl,t,istsoil) * wt_polygon(nl,t,ilowcenpoly)
+          wt_lunit(nl,t,istflatcenpoly) = wt_lunit(nl,t,istsoil) * wt_polygon(nl,t,iflatcenpoly)
+          wt_lunit(nl,t,isthighcenpoly) = wt_lunit(nl,t,istsoil) * wt_polygon(nl,t,ihighcenpoly)
+          wt_lunit(nl,t,istsoil) = wt_lunit(nl,t,istsoil) - sum(wt_lunit(nl,t,istlowcenpoly:isthighcenpoly))
+          ! check to make sure istsoil weight is still positive:
+          if (wt_lunit(nl,t,istsoil) .lt. 0_r8) then
+            call endrun(msg='ERROR:Polygonal tundra fraction > 100% in surface file'//&
+                                   errMsg(__FILE__, __LINE__))
+          end if
+        end do
+      end do
+    end if
+    write(iulog,*) "DEBUG 1 - wt_lunit is:", wt_lunit(begg:endg,1,:)
+    write(iulog,*) "DEBUG 2 - wt_polygon is:", wt_polygon(begg:endg,1,:)
+    write(iulog,*) "DEBUG 3 - wt_nat_patch is:", wt_nat_patch(begg:endg,1,:)
 
   end subroutine surfrd_veg_all
 

--- a/components/elm/src/main/surfrdMod.F90
+++ b/components/elm/src/main/surfrdMod.F90
@@ -1194,8 +1194,6 @@ contains
       wt_polygon(begg:endg,1:max_topounits,ilowcenpoly) = arrayl(begg:endg,1:max_topounits)
     else
       wt_polygon(begg:endg,1:max_topounits,ilowcenpoly:ihighcenpoly) = 0._r8
-      ! this shouldn't be necessary any more, as istolowcenpoly:isthighcenpoly
-     ! wt_lunit(begg:endg,1:max_topounits,istlowcenpoly:isthighcenpoly) = 0._r8
     endif
 
     ! add two other types
@@ -1366,9 +1364,6 @@ contains
         end do
       end do
     end if
-    write(iulog,*) "DEBUG 1 - wt_lunit is:", wt_lunit(begg:endg,1,:)
-    write(iulog,*) "DEBUG 2 - wt_polygon is:", wt_polygon(begg:endg,1,:)
-    write(iulog,*) "DEBUG 3 - wt_nat_patch is:", wt_nat_patch(begg:endg,1,:)
 
   end subroutine surfrd_veg_all
 

--- a/components/elm/src/main/surfrdMod.F90
+++ b/components/elm/src/main/surfrdMod.F90
@@ -1194,7 +1194,8 @@ contains
       wt_polygon(begg:endg,1:max_topounits,ilowcenpoly) = arrayl(begg:endg,1:max_topounits)
     else
       wt_polygon(begg:endg,1:max_topounits,ilowcenpoly:ihighcenpoly) = 0._r8
-      wt_lunit(begg:endg,1:max_topounits,istlowcenpoly:isthighcenpoly) = 0._r8
+      ! this shouldn't be necessary any more, as istolowcenpoly:isthighcenpoly
+     ! wt_lunit(begg:endg,1:max_topounits,istlowcenpoly:isthighcenpoly) = 0._r8
     endif
 
     ! add two other types

--- a/components/elm/src/main/surfrdUtilsMod.F90
+++ b/components/elm/src/main/surfrdUtilsMod.F90
@@ -72,7 +72,6 @@ contains
     if (found) then
        write(iulog,*) trim(caller), ' ERROR: sum of ', trim(name), ' not 1.0 at nl=', nindx, ' and t=', tindx
        write(iulog,*) 'sum is: ', sum(arr(nindx,t,:))
-       write(iulog,*) arr(nindx,t,:)
        call endrun(msg=errMsg(__FILE__, __LINE__))
     end if
 

--- a/components/elm/src/main/surfrdUtilsMod.F90
+++ b/components/elm/src/main/surfrdUtilsMod.F90
@@ -72,6 +72,7 @@ contains
     if (found) then
        write(iulog,*) trim(caller), ' ERROR: sum of ', trim(name), ' not 1.0 at nl=', nindx, ' and t=', tindx
        write(iulog,*) 'sum is: ', sum(arr(nindx,t,:))
+       write(iulog,*) arr(nindx,t,:)
        call endrun(msg=errMsg(__FILE__, __LINE__))
     end if
 


### PR DESCRIPTION
Description of changes:
Adds a representation of polygonal tundra that has been parameterized from simulations using the Advanced Terrestrial Simulator. Key changes include:

1. Two namelist options - use_polygonal_tundra, which turns on and off the polygonal tundra feature; and use_arctic_init, which provides a new cold and saturated start option to prevent Arctic soils from being too dry at depth due to rapid freezing in shallower soil layers.
2. Several changes to subgrid weighting are made to allow for addition of three different polygon type land units. These polygon land unit types otherwise need to have type istsoil, and so they are added to both the landunit and a new wt_polygon weighting array. When `use_polygonal_tundra = .false.`, wt_polygon is 0 and wt_lunit(:,:,istsoil) is unchanged). When `use_polygonal_tundra = .true.`, wt_polygon is read from the surface file as PCT_LCP, PCT_HCP, and PCT_FCP, and then wt_lunit is set as follows: wt_lunit(:,:,isthighcenpoly) = wt_polygon(:,:,ihighcenpoly)*wt_lunit(:,:,istsoil), wt_lunit(:,:,istflatcenpoly) = wt_polygon(:,:,iflatcenpoly)*wt_lunit(:,:,istsoil), wt_lunit(:,:,istlowcenpoly) = wt_polygon(:,:,ilowcenpoly)*wt_lunit(:,:,istsoil). wt_lunit(:,:,istsoil) is then updated as: wt_lunit(:,:,istsoil) - sum(wt_polygon(:,:,:)). 
3. Adds several new variables to track ice wedge polygon microtopography.
4. (still need to update here)

Test results: bit-for-bit with respect to 5559a57.

Expected performance impact: minimal when feature is off. When feature is on, adds up to 3 landunits to tundra grid cells, which may increase cost in these grid cells by up to ~4x if the only landunit previously had been istsoil.

cc'ing @chuckaustin @katrinaebennett for awareness